### PR TITLE
feat: complete migration from metanorma/iso-10303#65, rubocop fixes a…

### DIFF
--- a/lib/suma/collection_config.rb
+++ b/lib/suma/collection_config.rb
@@ -18,9 +18,5 @@ module Suma
     def to_file(path)
       File.open(path, "w") { |f| f.write to_yaml }
     end
-
-    def expand_schemas_only(path)
-      manifest.expand_schemas_only(path)
-    end
   end
 end

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -45,9 +45,9 @@ module Suma
     def expand_schemas_only(schema_output_path)
       unless schemas_only
         entry or return [self]
-        ret = entry.each_with_object([]) do |e|
+        ret = entry.each_with_object([]) do |e, m|
                  add = e.expand_schemas_only(schema_output_path)
-                 add.each { |x| ret << x }
+                 add.each { |x| m << x }
                end
         self.entry = ret
         return [self]

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -37,10 +37,7 @@ module Suma
     end
 
     def all_express_docs
-      puts "self is_express_doc (#{is_express_doc}): #{self}"
-      entry&.map do |manifest|
-        manifest.all_express_docs
-      end.flatten.compact + (is_express_doc ? [self] : [])
+      entry&.map(&:all_express_docs)&.flatten&.compact&.+ (is_express_doc ? [self] : [])
     end
 
     attr_accessor :schema_xml_files
@@ -73,7 +70,7 @@ module Suma
           identifier: schema.id,
           title: schema.id,
           file: File.join(schema_output_path, "doc_#{schema.id}", fname),
-          type: "express_doc", # This means this schema is a SchemaDocument
+          type: "express_doc" # This means this schema is a SchemaDocument
         )
       end
 
@@ -81,8 +78,8 @@ module Suma
         CollectionManifest.new(
           title: doc_id,
           type: "document",
-          entry: entries,
-        ),
+          entry: entries
+        )
       ]
     end
   end

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -83,9 +83,9 @@ module Suma
       # we need to separate this file from the following new entries
       
       added = CollectionManifest.new(
-        added.title = "Collection",
-        added.type = "collection",
-        added.identifier = self.identifier + "_"
+        title: "Collection",
+        type:  "collection",
+        identifier: self.identifier + "_"
       )
 
       added.entry = [

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -8,6 +8,8 @@ module Suma
   class CollectionManifest < Metanorma::Collection::Config::Manifest
     attribute :schemas_only, Shale::Type::Boolean
     attribute :entry, CollectionManifest, collection: true
+    attribute :schema_source, Shale::Type::String
+    attr_accessor :schema_config
 
     yaml do
       map "identifier", to: :identifier
@@ -32,17 +34,41 @@ module Suma
       model.entry = CollectionManifest.from_yaml(value.to_yaml)
     end
 
-    def is_express_doc
-      type == "express_doc"
+    def export_schema_config(path)
+      export_config = @schema_config || Suma::SchemaConfig::Config.new
+      entry&.map do |x|
+        x.export_schema_config(path)
+      end.compact.each_with_object(export_config) do |x, acc|
+        acc.concat(x)
+        acc
+      end
+      export_config
     end
 
-    def all_express_docs
-      entry&.map(&:all_express_docs)&.flatten&.compact&.+ (is_express_doc ? [self] : [])
+    def lookup(attr_sym, match)
+      (entry.select do |e|
+        e.send(attr_sym) == match
+      end + [self.send(attr_sym) == match ? self.send(attr_sym) : nil]).compact
     end
-
-    attr_accessor :schema_xml_files
 
     def expand_schemas_only(schema_output_path)
+      unless file
+        entry or return [self]
+        ret = entry.each_with_object([]) do |e, m|
+                 add = e.expand_schemas_only(schema_output_path)
+                 add.each { |x| m << x }
+               end
+        self.entry = ret
+        return [self]
+      end
+
+      if File.basename(file) == 'collection.yml'
+        schemas_yaml_path = File.join(File.dirname(file), "schemas.yaml")
+        if schemas_yaml_path && File.exist?(schemas_yaml_path)
+          @schema_config = Suma::SchemaConfig::Config.from_file(schemas_yaml_path)
+        end
+      end
+
       unless schemas_only
         entry or return [self]
         ret = entry.each_with_object([]) do |e, m|
@@ -53,15 +79,6 @@ module Suma
         return [self]
       end
 
-      # This is the collection.yml file path
-      # doc = YAML.safe_load(File.read(file))
-      doc = CollectionConfig.from_file(file)
-      doc_id = doc.bibdata.id
-
-      # This is the schemas.yml file path
-      schemas_yaml_path = File.join(File.dirname(file), "schemas.yaml")
-      schema_config = SchemaConfig::Config.from_file(schemas_yaml_path)
-
       # The schemas can't load if the file is removed
       # self.file = nil
       # If we are going to keep the schemas-only file and compile it, we can't have it showing up in output
@@ -69,20 +86,27 @@ module Suma
       #self.title = "Collection"
       #self.type = "collection"
 
-      entries = schema_config.schemas.map do |schema|
+      # This is the collection.yml file path
+      doc = CollectionConfig.from_file(file)
+      doc_id = doc.bibdata.id
+
+      # pp @schema_config
+
+      entries = @schema_config.schemas.map do |schema|
         # TODO: We compile these later, but where is the actual compile command?
         # Answer: in manifest_compile_adoc, on postprocess, end of initialisation of manifest object
         fname = [File.basename(schema.path, ".exp"), ".xml"].join
+
         CollectionManifest.new(
           identifier: schema.id,
           title: schema.id,
           file: File.join(schema_output_path, "doc_#{schema.id}", fname),
-          type: "express_doc" # This means this schema is a SchemaDocument
+          type: "express_doc", # This means this schema is a SchemaDocument
+          schema_source: schema.path
         )
       end
 
       # we need to separate this file from the following new entries
-      
       added = CollectionManifest.new(
         title: "Collection",
         type:  "collection",
@@ -93,8 +117,8 @@ module Suma
         CollectionManifest.new(
           title: doc_id,
           type: "document",
-          entry: entries
-        )
+          entry: entries,
+        ),
       ]
 
       [self, added]

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -50,6 +50,7 @@ module Suma
                  add.each { |x| ret << x }
                end
         self.entry = ret
+        return [self]
       end
 
       # This is the collection.yml file path

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -8,7 +8,7 @@ module Suma
   class CollectionManifest < Metanorma::Collection::Config::Manifest
     attribute :schemas_only, Shale::Type::Boolean
     attribute :entry, CollectionManifest, collection: true
-    attribute :schema_source, Shale::Type::String
+    # attribute :schema_source, Shale::Type::String
     attr_accessor :schema_config
 
     yaml do
@@ -36,32 +36,39 @@ module Suma
 
     def export_schema_config(path)
       export_config = @schema_config || Suma::SchemaConfig::Config.new
-      entry&.map do |x|
-        x.export_schema_config(path)
-      end.compact.each_with_object(export_config) do |x, acc|
-        acc.concat(x)
-        acc
+      return export_config unless entry
+
+      entry.each do |x|
+        child_config = x.export_schema_config(path)
+        export_config.concat(child_config) if child_config
       end
+
       export_config
     end
 
     def lookup(attr_sym, match)
-      (entry.select do |e|
-        e.send(attr_sym) == match
-      end + [self.send(attr_sym) == match ? self.send(attr_sym) : nil]).compact
+      results = entry.select { |e| e.send(attr_sym) == match }
+      results << self if send(attr_sym) == match
+      results
+    end
+
+    def process_entry(schema_output_path)
+      return [self] unless entry
+
+      ret = entry.each_with_object([]) do |e, m|
+        add = e.expand_schemas_only(schema_output_path)
+        m.concat(add)
+      end
+
+      self.entry = ret
+      [self]
     end
 
     def expand_schemas_only(schema_output_path)
-      unless file
-        entry or return [self]
-        ret = entry.each_with_object([]) do |e, m|
-                 add = e.expand_schemas_only(schema_output_path)
-                 add.each { |x| m << x }
-               end
-        self.entry = ret
-        return [self]
-      end
+      return process_entry(schema_output_path) unless file
 
+      # If there is collection.yml, this is a document collection, we process
+      # schemas.yaml.
       if File.basename(file) == 'collection.yml'
         schemas_yaml_path = File.join(File.dirname(file), "schemas.yaml")
         if schemas_yaml_path && File.exist?(schemas_yaml_path)
@@ -69,40 +76,23 @@ module Suma
         end
       end
 
-      unless schemas_only
-        entry or return [self]
-        ret = entry.each_with_object([]) do |e, m|
-                 add = e.expand_schemas_only(schema_output_path)
-                 add.each { |x| m << x }
-               end
-        self.entry = ret
-        return [self]
-      end
+      return process_entry(schema_output_path) unless schemas_only
 
-      # The schemas can't load if the file is removed
-      # self.file = nil
-      # If we are going to keep the schemas-only file and compile it, we can't have it showing up in output
+      # If we are going to keep the schemas-only file and compile it, we can't
+      # have it showing up in output.
       self.index = false
-      #self.title = "Collection"
-      #self.type = "collection"
 
-      # This is the collection.yml file path
       doc = CollectionConfig.from_file(file)
       doc_id = doc.bibdata.id
 
-      # pp @schema_config
-
       entries = @schema_config.schemas.map do |schema|
-        # TODO: We compile these later, but where is the actual compile command?
-        # Answer: in manifest_compile_adoc, on postprocess, end of initialisation of manifest object
         fname = [File.basename(schema.path, ".exp"), ".xml"].join
 
         CollectionManifest.new(
           identifier: schema.id,
           title: schema.id,
           file: File.join(schema_output_path, "doc_#{schema.id}", fname),
-          type: "express_doc", # This means this schema is a SchemaDocument
-          schema_source: schema.path
+          # schema_source: schema.path
         )
       end
 

--- a/lib/suma/express_schema.rb
+++ b/lib/suma/express_schema.rb
@@ -8,12 +8,9 @@ module Suma
   class ExpressSchema
     attr_accessor :path, :id, :parsed, :output_path
 
-    def initialize(path:, output_path:)
+    def initialize(id:, path:, output_path:)
       @path = Pathname.new(path).expand_path
-      @parsed = Expressir::Express::Parser.from_file(@path.to_s)
-      Utils.log "Loaded EXPRESS schema: #{path}"
-
-      @id = @parsed.schemas.first.id
+      @id = id
       @output_path = output_path
     end
 
@@ -28,8 +25,17 @@ module Suma
       end
     end
 
+    def parsed
+      return @parsed if @parsed
+
+      @parsed = Expressir::Express::Parser.from_file(@path.to_s)
+      Utils.log "Loaded EXPRESS schema: #{path}"
+      @id = @parsed.schemas.first.id
+      @parsed
+    end
+
     def to_plain
-      @parsed.to_s(no_remarks: true)
+      parsed.to_s(no_remarks: true)
     end
 
     def filename_plain

--- a/lib/suma/processor.rb
+++ b/lib/suma/processor.rb
@@ -15,7 +15,7 @@ module Suma
       # Can move to schema_config.rb
       def write_all_schemas(schemas_all_path, collection_config)
         # Gather all the inner (per-document) collection.yml files
-        document_paths = collection_config.manifest.entry.map(&:file)
+        document_paths = collection_config.manifest.entry.map(&:file).compact
 
         all_schemas = Suma::SchemaConfig::Config.new(path: schemas_all_path)
 

--- a/lib/suma/processor.rb
+++ b/lib/suma/processor.rb
@@ -14,7 +14,6 @@ module Suma
     class << self
       # Can move to schema_config.rb
       def write_all_schemas(schemas_all_path, collection_config)
-
         # Gather all the inner (per-document) collection.yml files
         document_paths = collection_config.manifest.entry.map(&:file)
 
@@ -50,14 +49,12 @@ module Suma
         collection_config.path = collection_config_path
         collection_config.manifest.expand_schemas_only("plain_schemas")
 
-        pp collection_config
-
         write_all_schemas(schemas_all_path, collection_config)
 
         col = Suma::SchemaCollection.new(
           config_yaml: schemas_all_path,
           output_path_docs: "schema_docs",
-          output_path_schemas: "plain_schemas",
+          output_path_schemas: "plain_schemas"
         )
 
         if compile
@@ -114,9 +111,9 @@ module Suma
             format: [:html],
             output_folder: output_directory,
             compile: {
-              no_install_fonts: true,
+              no_install_fonts: true
             },
-            coverpage: "cover.html",
+            coverpage: "cover.html"
           }
           metanorma_collection.render(collection_opts)
 

--- a/lib/suma/processor.rb
+++ b/lib/suma/processor.rb
@@ -12,31 +12,6 @@ require "metanorma/collection/collection"
 module Suma
   class Processor
     class << self
-      # Can move to schema_config.rb
-      def write_all_schemas(schemas_all_path, collection_config)
-        # Gather all the inner (per-document) collection.yml files
-        document_paths = collection_config.manifest.entry.map(&:file).compact
-
-        all_schemas = Suma::SchemaConfig::Config.new(path: schemas_all_path)
-
-        document_paths.each do |path|
-          schemas_yaml = File.join(File.dirname(path), "schemas.yaml")
-          next unless File.exist?(schemas_yaml)
-
-          schemas_config = Suma::SchemaConfig::Config.from_file(schemas_yaml)
-          all_schemas.concat(schemas_config)
-        end
-
-        schemas_only_list = collection_config.manifest.all_express_docs
-        schemas_only_list.each do |mani|
-          all_schemas.set_schemas_only(mani.identifier)
-        end
-
-        Utils.log "Writing #{schemas_all_path}..."
-        all_schemas.to_file
-        Utils.log "Done."
-      end
-
       def run(metanorma_yaml_path:, schemas_all_path:, compile:, output_directory: "_site")
         Utils.log "Current directory: #{Dir.getwd}"
 
@@ -49,12 +24,20 @@ module Suma
         collection_config.path = collection_config_path
         collection_config.manifest.expand_schemas_only("plain_schemas")
 
-        write_all_schemas(schemas_all_path, collection_config)
+        exported_schema_config = collection_config.manifest.export_schema_config(schemas_all_path)
+        exported_schema_config.path = schemas_all_path
+
+        pp exported_schema_config
+
+        Utils.log "Writing #{schemas_all_path}..."
+        exported_schema_config.to_file
+        Utils.log "Done."
 
         col = Suma::SchemaCollection.new(
           config_yaml: schemas_all_path,
+          manifest: collection_config.manifest,
           output_path_docs: "schema_docs",
-          output_path_schemas: "plain_schemas"
+          output_path_schemas: "plain_schemas",
         )
 
         if compile
@@ -111,9 +94,9 @@ module Suma
             format: [:html],
             output_folder: output_directory,
             compile: {
-              no_install_fonts: true
+              no_install_fonts: true,
             },
-            coverpage: "cover.html"
+            coverpage: "cover.html",
           }
           metanorma_collection.render(collection_opts)
 

--- a/lib/suma/processor.rb
+++ b/lib/suma/processor.rb
@@ -12,6 +12,7 @@ require "metanorma/collection/collection"
 module Suma
   class Processor
     class << self
+
       def run(metanorma_yaml_path:, schemas_all_path:, compile:, output_directory: "_site")
         Utils.log "Current directory: #{Dir.getwd}"
 
@@ -26,8 +27,6 @@ module Suma
 
         exported_schema_config = collection_config.manifest.export_schema_config(schemas_all_path)
         exported_schema_config.path = schemas_all_path
-
-        pp exported_schema_config
 
         Utils.log "Writing #{schemas_all_path}..."
         exported_schema_config.to_file

--- a/lib/suma/schema_attachment.rb
+++ b/lib/suma/schema_attachment.rb
@@ -73,7 +73,7 @@ module Suma
       @config = SchemaConfig::Config.new
       @config.schemas << SchemaConfig::Schema.new(
         id: @schema.id,
-        path: @schema.path,
+        path: @schema.path
       )
 
       @config
@@ -104,7 +104,7 @@ module Suma
       Metanorma::Compile.new.compile(
         filename_adoc,
         agree_to_terms: true,
-        no_install_fonts: true,
+        no_install_fonts: true
       )
       Utils.log "Compiling schema (id: #{id}, type: #{self.class}) => #{relative_path}... done!"
 
@@ -124,7 +124,7 @@ module Suma
         filename_adoc,
         filename_adoc("presentation.xml"),
         filename_adoc("adoc.lutaml.log.txt"),
-        filename_adoc("err.html"),
+        filename_adoc("err.html")
       ].each do |filename|
         FileUtils.rm_rf(filename)
       end

--- a/lib/suma/schema_attachment.rb
+++ b/lib/suma/schema_attachment.rb
@@ -6,7 +6,7 @@ require_relative "schema_config"
 
 module Suma
   class SchemaAttachment
-    attr_accessor :schema, :output_path, :config
+    attr_accessor :schema, :output_path, :config, :id
 
     def initialize(schema:, output_path:)
       @schema = schema
@@ -73,7 +73,7 @@ module Suma
       @config = SchemaConfig::Config.new
       @config.schemas << SchemaConfig::Schema.new(
         id: @schema.id,
-        path: @schema.path
+        path: @schema.path,
       )
 
       @config
@@ -100,13 +100,13 @@ module Suma
       save_adoc
 
       relative_path = Pathname.new(filename_adoc).relative_path_from(Dir.pwd)
-      Utils.log "Compiling schema #{relative_path}..."
+      Utils.log "Compiling schema (id: #{id}, type: #{self.class}) => #{relative_path}"
       Metanorma::Compile.new.compile(
         filename_adoc,
         agree_to_terms: true,
-        no_install_fonts: true
+        no_install_fonts: true,
       )
-      Utils.log "Compiling schema #{filename_adoc}...done!"
+      Utils.log "Compiling schema (id: #{id}, type: #{self.class}) => #{relative_path}... done!"
 
       # clean_artifacts
 
@@ -124,7 +124,7 @@ module Suma
         filename_adoc,
         filename_adoc("presentation.xml"),
         filename_adoc("adoc.lutaml.log.txt"),
-        filename_adoc("err.html")
+        filename_adoc("err.html"),
       ].each do |filename|
         FileUtils.rm_rf(filename)
       end

--- a/lib/suma/schema_collection.rb
+++ b/lib/suma/schema_collection.rb
@@ -15,21 +15,21 @@ module Suma
       @docs = []
       @schema_name_to_docs = {}
       @output_path_docs = if output_path_docs
-          Pathname.new(output_path_docs).expand_path
-        else
-          Pathname.new(Dir.pwd)
-        end
+                            Pathname.new(output_path_docs).expand_path
+                          else
+                            Pathname.new(Dir.pwd)
+                          end
       @output_path_schemas = if output_path_schemas
-          Pathname.new(output_path_schemas).expand_path
-        else
-          Pathname.new(Dir.pwd)
-        end
+                               Pathname.new(output_path_schemas).expand_path
+                             else
+                               Pathname.new(Dir.pwd)
+                             end
 
       @config = if config
-          config
-        elsif config_yaml
-          SchemaConfig::Config.from_file(config_yaml)
-        end
+                  config
+                elsif config_yaml
+                  SchemaConfig::Config.from_file(config_yaml)
+                end
     end
 
     def doc_from_schema_name(schema_name)
@@ -40,13 +40,13 @@ module Suma
       @config.schemas.each do |config_schema|
         s = ExpressSchema.new(
           path: config_schema.path,
-          output_path: @output_path_schemas,
+          output_path: @output_path_schemas
         )
 
         klass = config_schema.schemas_only ? SchemaDocument : SchemaAttachment
         doc = klass.new(
           schema: s,
-          output_path: @output_path_docs.join(s.id),
+          output_path: @output_path_docs.join(s.id)
         )
 
         @docs << doc

--- a/lib/suma/schema_collection.rb
+++ b/lib/suma/schema_collection.rb
@@ -39,8 +39,9 @@ module Suma
     def finalize
       @config.schemas.each do |config_schema|
         s = ExpressSchema.new(
-          path: config_schema.path,
-          output_path: @output_path_schemas
+          id: config_schema.id,
+          path: config_schema.path.to_s,
+          output_path: @output_path_schemas.to_s
         )
 
         klass = config_schema.schemas_only ? SchemaDocument : SchemaAttachment

--- a/lib/suma/schema_collection.rb
+++ b/lib/suma/schema_collection.rb
@@ -8,11 +8,12 @@ require_relative "utils"
 
 module Suma
   class SchemaCollection
-    attr_accessor :config, :schemas, :docs, :output_path_docs, :output_path_schemas
+    attr_accessor :config, :schemas, :docs, :output_path_docs, :output_path_schemas,
+      :manifest
 
-    def initialize(config: nil, config_yaml: nil, output_path_docs: nil, output_path_schemas: nil)
-      @schemas = []
-      @docs = []
+    def initialize(config: nil, config_yaml: nil, output_path_docs: nil, output_path_schemas: nil, manifest: nil)
+      @schemas = {}
+      @docs = {}
       @schema_name_to_docs = {}
       @output_path_docs = if output_path_docs
                             Pathname.new(output_path_docs).expand_path
@@ -30,36 +31,56 @@ module Suma
                 elsif config_yaml
                   SchemaConfig::Config.from_file(config_yaml)
                 end
+
+      @manifest = manifest
     end
 
     def doc_from_schema_name(schema_name)
       @schema_name_to_docs[schema_name]
     end
 
-    def finalize
-      @config.schemas.each do |config_schema|
+    def process_schemas(schemas, klass)
+      schemas.each do |config_schema|
         s = ExpressSchema.new(
           id: config_schema.id,
           path: config_schema.path.to_s,
           output_path: @output_path_schemas.to_s
         )
 
-        klass = config_schema.schemas_only ? SchemaDocument : SchemaAttachment
         doc = klass.new(
           schema: s,
           output_path: @output_path_docs.join(s.id)
         )
 
-        @docs << doc
-        @schemas << s
+        @docs[s.id] = doc
+        @schemas[s.id] = s
         @schema_name_to_docs[s.id] = doc
+      end
+    end
+
+    def finalize
+      # Process each schema in @config.schemas
+      process_schemas(@config.schemas, SchemaAttachment)
+
+      manifest_entry = @manifest.lookup(:schemas_only, true)
+
+      manifest_entry.each do |entry|
+        next unless entry.schema_config
+
+        # Process each schema in entry.schema_config.schemas
+        process_schemas(entry.schema_config.schemas, SchemaDocument)
       end
     end
 
     def compile
       finalize
-      schemas.map(&:save_exp)
-      docs.each(&:compile)
+      schemas.each_pair do |schema_id, entry|
+        entry.save_exp
+      end
+
+      docs.each_pair do |schema_id, entry|
+        entry.compile
+      end
 
       # TODO: make this parallel
       # Utils.log"Starting Ractor processing"

--- a/lib/suma/schema_config/config.rb
+++ b/lib/suma/schema_config/config.rb
@@ -8,7 +8,7 @@ module Suma
   module SchemaConfig
     class Config < Shale::Mapper
       attribute :schemas, Schema, collection: true
-      attr_accessor :base_path, :path, :schemas_only
+      attr_accessor :path
 
       def initialize(path: nil, **args)
         @path = path
@@ -35,10 +35,12 @@ module Suma
         end
       end
 
-      def set_schemas_only
-        schemas.each do |e|
-          e.schemas_only = true
+      def set_schemas_only(schema_name)
+        schema = schemas.detect do |e|
+          e.id == schema_name
         end
+
+        schema.schemas_only = true
       end
 
       def schemas_from_yaml(model, value)

--- a/lib/suma/schema_config/schema.rb
+++ b/lib/suma/schema_config/schema.rb
@@ -7,7 +7,7 @@ module Suma
     class Schema < Shale::Mapper
       attribute :id, Shale::Type::String
       attribute :path, Shale::Type::String
-      attribute :schemas_only, Shale::Type::Boolean
+      # attribute :schemas_only, Shale::Type::Boolean
     end
   end
 end

--- a/lib/suma/schema_document.rb
+++ b/lib/suma/schema_document.rb
@@ -4,16 +4,6 @@ require_relative "schema_attachment"
 
 module Suma
   class SchemaDocument < SchemaAttachment
-    def empty_title1(anchor)
-      a = anchor.gsub(/\}\}/, ' | replace: "\", "-"}}')
-      <<~HEREDOC
-        [[#{@id}.#{a}]]
-        [%unnumbered,type=express]
-        === {blank}
-
-      HEREDOC
-    end
-
     def bookmark(anchor)
       a = anchor.gsub(/\}\}/, ' | replace: "\", "-"}}')
       "[[#{@id}.#{a}]]"


### PR DESCRIPTION
Complete migration from:
* metanorma/iso-10303#65

The `schema-only` option now works when you set it in `collection.yml`.

That said the name `schema-only` is still nebulous. This switch differentiates between an HTML SchemaDocument with links or a plain HTML SchemaAttachment with no links.

@opoudjis for your review.