### PR TITLE
Complete schemas-only anchors

### DIFF
--- a/lib/suma/schema_document.rb
+++ b/lib/suma/schema_document.rb
@@ -46,6 +46,42 @@ module Suma
         #{bookmark("{{thing.id}}")}
         {% endfor %}
         {% endif %}
+
+        // _subtype_constraints.liquid
+        {% if schema.subtype_constraints.size > 0 %}
+        #{bookmark("subtype_constraints")}
+        // _subtype_constraint.liquid
+        {% for thing in schema.subtype_constraints %}
+        #{bookmark("{{thing.id}}")}
+        {% endfor %}
+        {% endif %}
+
+        // _functions.liquid
+        {% if schema.functions.size > 0 %}
+        #{bookmark("functions")}
+        // _function.liquid
+        {% for thing in schema.functions %}
+        #{bookmark("{{thing.id}}")}
+        {% endfor %}
+        {% endif %}
+
+        // _procedures.liquid
+        {% if schema.procedures.size > 0 %}
+        #{bookmark("procedures")}
+        // _procedure.liquid
+        {% for thing in schema.procedures %}
+        #{bookmark("{{thing.id}}")}
+        {% endfor %}
+        {% endif %}
+
+        // _rules.liquid
+        {% if schema.rules.size > 0 %}
+        #{bookmark("rules")}
+        // _rule.liquid
+        {% for thing in schema.rules %}
+        #{bookmark("{{thing.id}}")}
+        {% endfor %}
+        {% endif %}
       HEREDOC
     end
 


### PR DESCRIPTION
Fixes https://github.com/metanorma/iso-10303/issues/73

In this PR, I have just completed the anchors of the schemas-only docs.
I've confirmed the anchors fulfill with this structure:

```
== action_schema [[action_schema_funds]]
{% if schema.constants.size > 0 %}[[action_schema.constants]]{% for thing in schema.constants %}[[action_schema.{{thing.id | replace: "\", "-"}}]]{% endfor %}{% endif %}
{% if schema.types.size > 0 %}[[action_schema.types]]{% for thing in schema.types %}[[action_schema.{{thing.id | replace: "\", "-"}}]]
{% if thing.items.size > 0 %}[[action_schema.{{thing.id | replace: "\", "-"}}.items]]{% for item in thing.items %}[[action_schema.{{thing.id | replace: "\", "-"}}.items.{{item.id | replace: "\", "-"}}]]{% endfor %}{% endif %}{% endfor %}{% endif %}
{% if schema.entities.size > 0 %}[[action_schema.entities]]{% for thing in schema.entities %}[[action_schema.{{thing.id | replace: "\", "-"}}]]{% endfor %}{% endif %}
```