### PR TITLE
wip: migrate to lutaml-model from shale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 13.0"
-
 gem "rspec", "~> 3.0"
-
-gem "rubocop", "~> 1.21"
+gem "rubocop"
+gem "rubocop-performance"
+gem "rubocop-rails"

--- a/lib/suma/collection_config.rb
+++ b/lib/suma/collection_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "utils"
-require "shale"
+require "lutaml/model"
 require_relative "collection_manifest"
 require "metanorma/cli"
 require "metanorma/cli/collection"

--- a/lib/suma/collection_manifest.rb
+++ b/lib/suma/collection_manifest.rb
@@ -6,15 +6,15 @@ require "metanorma/collection/collection"
 
 module Suma
   class CollectionManifest < Metanorma::Collection::Config::Manifest
-    attribute :schemas_only, Shale::Type::Boolean
+    attribute :schemas_only, Lutaml::Model::Type::Boolean
     attribute :entry, CollectionManifest, collection: true
-    # attribute :schema_source, Shale::Type::String
+    # attribute :schema_source, Lutaml::Model::Type::String
     attr_accessor :schema_config
 
     yaml do
       map "identifier", to: :identifier
       map "type", to: :type
-      map "level", using: { from: :level_from_yaml, to: :nop_to_yaml }
+      map "level", with: { from: :level_from_yaml, to: :nop_to_yaml }
       map "title", to: :title
       map "url", to: :url
       map "attachment", to: :attachment
@@ -22,12 +22,12 @@ module Suma
       map "schemas-only", to: :schemas_only
       map "index", to: :index
       map "file", to: :file
-      map "fileref", using: { from: :fileref_from_yaml, to: :nop_to_yaml }
+      map "fileref", with: { from: :fileref_from_yaml, to: :nop_to_yaml }
       map "entry", to: :entry
-      map "docref", using: { from: :docref_from_yaml, to: :nop_to_yaml }
-      map "manifest", using: { from: :docref_from_yaml, to: :nop_to_yaml }
-      map "bibdata", using: { from: :bibdata_from_yaml,
-                              to: :bibdata_to_yaml }
+      map "docref", with: { from: :docref_from_yaml, to: :nop_to_yaml }
+      map "manifest", with: { from: :docref_from_yaml, to: :nop_to_yaml }
+      map "bibdata", with: { from: :bibdata_from_yaml,
+                             to: :bibdata_to_yaml }
     end
 
     def docref_from_yaml(model, value)

--- a/lib/suma/schema_config/config.rb
+++ b/lib/suma/schema_config/config.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require "shale"
+require "lutaml/model"
 require_relative "schema"
 require_relative "../utils"
 
 module Suma
   module SchemaConfig
-    class Config < Shale::Mapper
+    class Config < Lutaml::Model::Serializable
       attribute :schemas, Schema, collection: true
-      attribute :path, Shale::Type::String
+      attribute :path, Lutaml::Model::Type::String
       attr_accessor :output_path
 
       def initialize(**args)
@@ -21,7 +21,7 @@ module Suma
       end
 
       yaml do
-        map "schemas", using: { from: :schemas_from_yaml, to: :schemas_to_yaml }
+        map "schemas", with: { from: :schemas_from_yaml, to: :schemas_to_yaml }
       end
 
       def self.from_file(path)

--- a/lib/suma/schema_config/schema.rb
+++ b/lib/suma/schema_config/schema.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "shale"
+require "lutaml/model"
 
 module Suma
   module SchemaConfig
-    class Schema < Shale::Mapper
-      attribute :id, Shale::Type::String
-      attribute :path, Shale::Type::String
-      # attribute :schemas_only, Shale::Type::Boolean
+    class Schema < Lutaml::Model::Serializable
+      attribute :id, Lutaml::Model::Type::String
+      attribute :path, Lutaml::Model::Type::String
+      # attribute :schemas_only, Lutaml::Model::Type::Boolean
 
       # container_path is a copy of Suma::SchemaConfig::Config.path,
       # used to resolve the path of each schema within

--- a/lib/suma/site_config.rb
+++ b/lib/suma/site_config.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-require "shale"
+require "lutaml/model"
 
 module Suma
   module SiteConfig
-    class SiteInfo < Shale::Mapper
-      attribute :organization, Shale::Type::String
-      attribute :name, Shale::Type::String
+    class SiteInfo < Lutaml::Model::Serializable
+      attribute :organization, Lutaml::Model::Type::String
+      attribute :name, Lutaml::Model::Type::String
     end
 
-    class Sources < Shale::Mapper
-      attribute :files, Shale::Type::String, collection: true
+    class Sources < Lutaml::Model::Serializable
+      attribute :files, Lutaml::Model::Type::String, collection: true
     end
 
-    class Base < Shale::Mapper
+    class Base < Lutaml::Model::Serializable
       attribute :source, Sources
       attribute :collection, SiteInfo
     end
 
-    class Config < Shale::Mapper
+    class Config < Lutaml::Model::Serializable
       attribute :metanorma, Base
 
       def self.from_file(path)

--- a/suma.gemspec
+++ b/suma.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.require_paths = ["lib"]
 
   spec.add_dependency "expressir"
-  spec.add_dependency "metanorma-cli"
   spec.add_dependency "lutaml-model"
+  spec.add_dependency "metanorma-cli"
   spec.add_dependency "thor", ">= 0.20"
 end

--- a/suma.gemspec
+++ b/suma.gemspec
@@ -34,11 +34,8 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "expressir"
-  spec.add_runtime_dependency "metanorma-cli"
-  spec.add_runtime_dependency "shale"
-  spec.add_runtime_dependency "thor", ">= 0.20"
-  spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "rubocop-performance"
-  spec.add_development_dependency "rubocop-rails"
+  spec.add_dependency "expressir"
+  spec.add_dependency "metanorma-cli"
+  spec.add_dependency "lutaml-model"
+  spec.add_dependency "thor", ">= 0.20"
 end


### PR DESCRIPTION
@kwkwan can you please help us migrate to lutaml-model? The specs are failing right now with:

```
 bundle exec rake
~/.asdf/installs/ruby/3.3.2/bin/ruby -I~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib:~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.2/lib ~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Suma
[suma] Current directory: /private/var/folders/2t/xmdrn2sd2lv2w49dv0zw9_q00000gp/T/d20241221-47153-apohj8, writing schemas.yml...
[relaton-bib] WARN: Type `collection` is invalid.
[suma] [ERROR] Error occurred during processing. See details below.
[suma] undefined method `default' for nil
[suma] #<NoMethodError: undefined method `default' for nil>
[suma] ~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:385:in `block in apply_hash_mapping'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:377:in `each'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:377:in `apply_hash_mapping'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:314:in `apply_mappings'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/attribute.rb:227:in `cast'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:397:in `block in apply_hash_mapping'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:377:in `each'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:377:in `apply_hash_mapping'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:314:in `apply_mappings'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:122:in `block (2 levels) in <module:ClassMethods>'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:109:in `public_send'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/lutaml-model-0.3.30/lib/lutaml/model/serialize.rb:109:in `block (2 levels) in <module:ClassMethods>'
~/src/mn/suma/lib/suma/collection_config.rb:15:in `from_file'
~/src/mn/suma/lib/suma/processor.rb:39:in `export_schema_config'
~/src/mn/suma/lib/suma/processor.rb:17:in `run'
~/src/mn/suma/lib/suma/cli.rb:39:in `run'
~/src/mn/suma/lib/suma/cli.rb:26:in `build'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/thor-hollaback-0.2.1/lib/thor/hollaback.rb:68:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
~/src/mn/suma/lib/suma/thor_ext.rb:36:in `block in start'
~/src/mn/suma/lib/suma/thor_ext.rb:45:in `handle_help_switches'
~/src/mn/suma/lib/suma/thor_ext.rb:35:in `start'
~/src/mn/suma/spec/suma/cli_spec.rb:24:in `block (2 levels) in <top (required)>'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:263:in `instance_exec'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:263:in `block in run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:486:in `block in run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:352:in `call'
~/src/mn/suma/spec/suma/cli_spec.rb:18:in `block (4 levels) in <top (required)>'
~/src/mn/suma/spec/suma/cli_spec.rb:17:in `chdir'
~/src/mn/suma/spec/suma/cli_spec.rb:17:in `block (3 levels) in <top (required)>'
~/.asdf/installs/ruby/3.3.2/lib/ruby/3.3.0/tmpdir.rb:99:in `mktmpdir'
~/src/mn/suma/spec/suma/cli_spec.rb:8:in `block (2 levels) in <top (required)>'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:457:in `instance_exec'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:457:in `instance_exec'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:390:in `execute_with'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:352:in `call'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:486:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:259:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:646:in `block in run_examples'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:642:in `map'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:642:in `run_examples'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:607:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:121:in `map'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:116:in `block in run_specs'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/reporter.rb:74:in `report'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:115:in `run_specs'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:89:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:71:in `run'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:45:in `invoke'
~/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.2/exe/rspec:4:in `<main>'
  Build simple metanorma.yml manifest (FAILED - 1)
  raise ENOENT for missing manifest
[Errno::ENOENT] No such file or directory - Specified Metanorma site manifest file `not-found.yml` not found.
  non-zero exit code for missing manifest

Suma
  has a version number

Failures:

  1) Suma Build simple metanorma.yml manifest
     Failure/Error: expect(File.exist?("schemas.yml")).to be true
     
       expected true
            got false
     # ./spec/suma/cli_spec.rb:26:in `block (2 levels) in <top (required)>'
     # ./spec/suma/cli_spec.rb:18:in `block (4 levels) in <top (required)>'
     # ./spec/suma/cli_spec.rb:17:in `chdir'
     # ./spec/suma/cli_spec.rb:17:in `block (3 levels) in <top (required)>'
     # ./spec/suma/cli_spec.rb:8:in `block (2 levels) in <top (required)>'

Finished in 0.10002 seconds (files took 2.28 seconds to load)
4 examples, 1 failure

Failed examples:

rspec ./spec/suma/cli_spec.rb:23 # Suma Build simple metanorma.yml manifest
```

Basically, you can follow the errors using this command at the `iso-10303` repo:

```
# Make sure Gemfile uses this branch of `suma`, then:
bundle exec suma build metanorma-smol.yml
```

Fixes #17 
Fixes #19
