### PR TITLE
chore: add permissions to CI workflows (Cimas sync)

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -2,6 +2,9 @@
 # See https://github.com/metanorma/cimas
 name: rake
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@
 # See https://github.com/metanorma/cimas
 name: release
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,4 +27,3 @@ jobs:
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
-


### PR DESCRIPTION
Replaces #88.

The original PR #88 tried to sync the full Cimas workflow templates, but those changes conflicted with our current codebase (stale .rubocop.yml simplification, removed plugin declarations, outdated .rubocop_todo.yml).

This PR takes only the essential change: adding explicit `permissions` blocks to both CI workflows, following the [metanorma/ci](https://github.com/metanorma/ci) best practices.

**Changes:**
- `rake.yml`: adds `permissions: contents: read`
- `release.yml`: adds `permissions: contents: write, packages: write, id-token: write`

Closes #88