### PR TITLE
fix(cli): declare options on Core for extract-terms and generate-register

### DIFF
--- a/lib/suma/cli/core.rb
+++ b/lib/suma/cli/core.rb
@@ -40,14 +40,42 @@ module Suma
       desc "extract-terms SCHEMA_MANIFEST_FILE GLOSSARIST_OUTPUT_PATH",
            "Extract terms from SCHEMA_MANIFEST_FILE into " \
            "Glossarist v3 format"
-      def extract_terms(_schema_manifest_file, _glossarist_output_path)
-        Cli::ExtractTerms.start
+      option :urn, type: :string, required: true, aliases: "-u",
+                   desc: "URN for the dataset source " \
+                         "(used for section references)"
+      option :language_code, type: :string, default: "eng", aliases: "-l",
+                             desc: "Language code for the Glossarist"
+      def extract_terms(schema_manifest_file, glossarist_output_path)
+        TermExtractor.new(
+          schema_manifest_file,
+          glossarist_output_path,
+          urn: options[:urn],
+          language_code: options[:language_code],
+        ).call
       end
 
       desc "generate-register SCHEMA_MANIFEST_FILE OUTPUT_PATH",
            "Generate a Glossarist register.yaml with hierarchical sections"
-      def generate_register(_schema_manifest_file, _output_path)
-        Cli::GenerateRegister.start
+      option :urn, type: :string, required: true, aliases: "-u",
+                   desc: "URN prefix for the dataset"
+      option :id, type: :string, required: true,
+                  desc: "Dataset identifier (e.g. iso10303-2-express)"
+      option :ref, type: :string, required: true,
+                   desc: "Human-readable reference label"
+      option :language_code, type: :string, default: "eng", aliases: "-l",
+                             desc: "Language code for section names"
+      option :owner, type: :string, default: Suma::RegisterManifestGenerator::DEFAULT_OWNER,
+                     desc: "Owner of the dataset (e.g. 'ISO/TC 184/SC 4')"
+      def generate_register(schema_manifest_file, output_path)
+        RegisterManifestGenerator.new(
+          schema_manifest_file,
+          output_path,
+          urn: options[:urn],
+          id: options[:id],
+          ref: options[:ref],
+          language_code: options[:language_code],
+          owner: options[:owner],
+        ).generate
       end
 
       desc "convert-jsdai XML_FILE IMAGE_FILE OUTPUT_DIR",


### PR DESCRIPTION
## Problem

The double-Thor pattern (Core delegates to `Cli::ExtractTerms.start`, which reparses ARGV) was broken because `Core` has `check_unknown_options!` enabled via `ThorExt::Start`. This caused Core to reject any options declared only on the inner Thor class.

## Symptoms

```sh
$ suma extract-terms --urn urn:iso:std:iso:10303:-2:* schemas-smrl-part-2.yml /tmp/out
Unknown switches "--urn"

$ suma generate-schemas --exclude-paths '*_lf.exp' metanorma-smrl-all.yml out.yml
Unknown switches "--exclude-paths"

$ suma generate-register --urn ... --id ... --ref ... schemas-smrl-part-2.yml register.yaml
Unknown switches "--urn"
```

All commands that take options beyond their positional args are affected.

## Fix

Declare the options directly on the `Core` methods and call the underlying service classes (`TermExtractor`, `RegisterManifestGenerator`) directly, bypassing the inner Thor wrapper.

The inner classes (`Cli::ExtractTerms`, `Cli::GenerateRegister`) are kept as backwards-compat entry points — they still work if invoked directly via `Cli::ExtractTerms.start`.

## Verification

```sh
$ bundle exec ruby exe/suma extract-terms --urn 'urn:iso:std:iso:10303:-2:*' \
    /path/to/schemas-smrl-part-2.yml /tmp/concepts-test
[suma] Building terms: schemas/modules/activity/arm.exp
[suma] Saving collection to files in: /tmp/concepts-test
...
$ find /tmp/concepts-test -name '*.yaml' | wc -l
7362
```

Both `extract-terms --urn` and `generate-register --urn --id --ref` now work as documented.

## Out of scope (follow-up)

- The other inner-Thor commands (`build`, `reformat`, `convert-jsdai`, `export`, `compare`) likely have the same bug if they take options. Worth auditing in a separate PR if any of them have inner-class options.
- Could remove the now-redundant inner Thor classes once confident nothing else uses them.

## Related

- Discovered while adding the iso-10303-2 concept-extraction validation workflow (PR on metanorma/iso-10303: `to-iso/feature/TCSC410303-3005-iso-10303-2-upgrade-to-latest-suma-workflow-enable-concept-browser`).