### PR TITLE
docs: add TODO.update plans for the next four refactor PRs

### DIFF
--- a/TODO.update/03-drop-redundant-schema-name-to-docs.md
+++ b/TODO.update/03-drop-redundant-schema-name-to-docs.md
@@ -1,0 +1,88 @@
+# TODO.update/03 — Drop redundant `@schema_name_to_docs` hash in SchemaCollection
+
+> Source: v0.3.0 audit follow-up. Small, safe, no behavior change.
+
+## Current state
+
+`lib/suma/schema_collection.rb:13-14, 25, 72-74` keeps two parallel hashes that
+store the same `id → compiler` mapping:
+
+```ruby
+def initialize(...)
+  @schemas = {}
+  @docs = {}
+  @schema_name_to_docs = {}   # ← duplicate of @docs
+end
+
+def doc_from_schema_name(schema_name)
+  @schema_name_to_docs[schema_name]
+end
+
+def process_schema(...)
+  @docs[express.id] = compiler
+  @schemas[express.id] = express
+  @schema_name_to_docs[express.id] = compiler   # ← duplicate write
+end
+```
+
+## Problem
+
+Two homes for one piece of state violates single source of truth. Every
+write site must remember to update both. Every reader must know which
+hash to consult. They can drift.
+
+External callers of `doc_from_schema_name`: none. Verified with
+`grep -rn 'doc_from_schema_name' lib/ spec/ exe/` — only the class
+itself and a single spec that exercises the reader.
+
+## Proposed change
+
+Single source of truth: `@docs` only.
+
+```ruby
+def initialize(...)
+  @schemas = {}
+  @docs = {}
+  ...
+end
+
+def doc_from_schema_name(schema_name)
+  @docs[schema_name]
+end
+
+def process_schema(...)
+  @docs[express.id] = compiler
+  @schemas[express.id] = express
+end
+```
+
+Net: −4 lines, one less ivar, one less write per schema.
+
+## Files
+
+- `lib/suma/schema_collection.rb` — remove `@schema_name_to_docs`, repoint
+  `doc_from_schema_name` to `@docs`.
+
+## Spec impact
+
+None. `doc_from_schema_name` continues to work identically. Existing
+specs (when added) cover it through the public API.
+
+## Acceptance criteria
+
+- `grep -n 'schema_name_to_docs' lib/suma/` returns nothing
+- `bundle exec rspec` passes unchanged
+- `bundle exec rubocop` clean
+- No public API change
+
+## Out of scope
+
+- Renaming `@docs` to something more descriptive (`@compilers_by_id`)
+  — cosmetic, can do separately.
+- Removing `doc_from_schema_name` if no external caller — keep for now
+  as a documented public reader.
+
+## Suggested PR scope
+
+Single commit:
+`refactor: drop redundant @schema_name_to_docs hash in SchemaCollection`

--- a/TODO.update/04-processor-configurable-paths.md
+++ b/TODO.update/04-processor-configurable-paths.md
@@ -1,0 +1,124 @@
+# TODO.update/04 — Make Processor paths configurable
+
+> Source: v0.3.0 audit follow-up. Backwards-compatible.
+
+## Current state
+
+`lib/suma/processor.rb` hardcodes four path literals:
+
+```ruby
+def initialize(metanorma_yaml_path:, schemas_all_path:, compile: true,
+               output_directory: "_site")            # ← (1) "_site" is kwarg
+  ...
+end
+
+def export_schema_config
+  ...
+  traverser.expand_schemas_only("schema_docs")       # ← (2) hardcoded
+  ...
+end
+
+def compile_schema(schemas_all_path, collection_config)
+  col = Suma::SchemaCollection.new(
+    config_yaml: schemas_all_path,
+    manifest: collection_config.manifest,
+    output_path_docs: "schema_docs",                 # ← (3) hardcoded
+    output_path_schemas: "plain_schemas",            # ← (4) hardcoded
+  )
+  ...
+end
+
+def build_collection(collection_config, output_directory)
+  new_collection_config_path = "collection-output.yaml"   # ← (5) hardcoded
+  ...
+end
+```
+
+## Problem
+
+Processor's signature claims `output_directory:` is configurable but
+four other paths are not. A caller cannot redirect `schema_docs/`,
+`plain_schemas/`, or the intermediate collection YAML without
+subclassing. This bites:
+
+- Tests that want to write to a tmpdir (Processor specs currently
+  don't run end-to-end for this reason).
+- Users who want to integrate suma into a different layout.
+- The upcoming shared-cache work (PR #95), which benefits from a
+  configurable intermediate path.
+
+## Proposed change
+
+Promote the literals to keyword arguments with the current values as
+defaults. Backwards compatible.
+
+```ruby
+def initialize(metanorma_yaml_path:,
+               schemas_all_path:,
+               compile: true,
+               output_directory: "_site",
+               docs_subdir: "schema_docs",
+               schemas_subdir: "plain_schemas",
+               intermediate_collection_path: "collection-output.yaml")
+  @metanorma_yaml_path = metanorma_yaml_path
+  @schemas_all_path = schemas_all_path
+  @compile_flag = compile
+  @output_directory = output_directory
+  @docs_subdir = docs_subdir
+  @schemas_subdir = schemas_subdir
+  @intermediate_collection_path = intermediate_collection_path
+end
+```
+
+All internal methods reference the ivars; no literals remain inside
+private methods.
+
+## Files
+
+- `lib/suma/processor.rb` — add kwargs, replace literals.
+- `spec/suma/processor_spec.rb` — extend `#initialize` specs to cover
+  the new kwargs (defaults preserve current behavior; explicit values
+  are honored).
+
+## Spec requirements
+
+The current Processor spec only tests `#initialize`. Extend it:
+
+- Defaults: all four new kwargs default to the literals above.
+- Explicit values: passing `docs_subdir: "tmp/docs"` makes
+  `compile_schema` write to `tmp/docs`.
+- End-to-end smoke (optional, larger): construct Processor with
+  tmpdir paths and a tiny fixture, run, assert outputs land where
+  the kwargs say they do. This is a real integration test; the lack
+  of one is why Processor paths got away with being hardcoded.
+
+## Acceptance criteria
+
+- `grep -n '"schema_docs"\|"plain_schemas"\|"collection-output.yaml"' lib/suma/processor.rb` returns nothing
+- All existing specs pass unchanged (defaults preserve behavior)
+- New `#initialize` specs cover the new kwargs
+- `bundle exec rubocop` clean (watch AbcSize on `initialize` —
+  currently fine, but adding 4 kwargs may push it; if so, extract
+  to a `Suma::Processor::Paths` value object instead)
+
+## Out of scope
+
+- Suma::Paths value object — only if rubocop forces it.
+- Removing `output_directory:` (still useful as a top-level concept).
+- CLI surface (don't expose these as CLI flags unless asked).
+
+## Suggested PR scope
+
+Single commit:
+`refactor: promote Processor's hardcoded paths to constructor kwargs`
+
+If the kwargs make `initialize` too big, split into two commits:
+
+1. Add a `Suma::Processor::Paths` struct
+2. Use it in Processor
+
+## Follow-up
+
+If the kwargs count keeps growing, consider a `Suma::Config` value
+object that consolidates env vars (`SUMA_DEBUG`, `SUMA_SCHEMA_CACHE_DIR`)
+and CLI options. Out of scope here.

--- a/TODO.update/05-extract-note-extractor.md
+++ b/TODO.update/05-extract-note-extractor.md
@@ -1,0 +1,252 @@
+# TODO.update/05 — Extract Suma::NoteExtractor from TermExtractor
+
+> Source: v0.3.0 audit follow-up. Pure refactor, no behavior change.
+> Reduces TermExtractor from 25 private methods to a focused orchestrator.
+
+## Current state
+
+`lib/suma/term_extractor.rb` is 462 lines. Of those, ~210 are private
+methods devoted to turning `entity.remarks` (Annotated EXPRESS prose)
+into a clean array of `Glossarist::V3::DetailedDefinition` notes.
+
+The note-processing pipeline (in invocation order):
+
+```
+get_entity_notes(entity, schema_domain, definitions)
+  → trim_definition(entity.remarks)
+      → apply_first_sentence_logic(paragraph)
+      → extract_complete_list(paragraphs, start_index)
+          → starts_with_list?(content)               # shared
+          → is_list_continuation?(content)
+      → express_reference_to_mention(combined)       # shared with descriptions
+  → convert_express_xref(trimmed, schema_domain)     # separate gsub path
+  → only_keep_first_sentence(notes)
+      → should_preserve_complete_structure?(content)
+          → starts_with_list?(content)               # shared
+  → remove_see_content(notes)
+  → remove_redundant_note(notes)                     # uses REDUNDANT_NOTE_REGEX
+  → remove_invalid_references(notes)
+  → compare_with_definitions(notes, definitions)     # final guard
+```
+
+The shared helpers (`starts_with_list?`, `express_reference_to_mention`)
+bridge note extraction and definition generation. Everything else is
+note-specific.
+
+## Problem
+
+TermExtractor mixes three concerns:
+
+1. **Orchestration** — load manifest, walk schemas, build ManagedConcept.
+2. **Definition generation** — `generate_entity_definition` (urn mentions
+   composed from schema_type).
+3. **Note extraction** — the 12-method pipeline above.
+
+This makes TermExtractor hard to read, hard to test in isolation, and
+hard to extend. Adding a new note-cleaning rule means editing a 462-line
+file alongside unrelated orchestration code.
+
+## Proposed split
+
+```
+Suma::TermExtractor (orchestrator)
+  ├─ loads manifest
+  ├─ builds ManagedConcept per entity
+  ├─ delegates notes to NoteExtractor
+  └─ delegates definitions to DefinitionBuilder (future)
+
+Suma::NoteExtractor (prose-cleaning pipeline)
+  ├─ input: entity.remarks, schema_domain, definition_for_comparison
+  ├─ output: Array<Glossarist::V3::DetailedDefinition>
+  └─ owns: trim_definition, apply_first_sentence_logic,
+           extract_complete_list, is_list_continuation?,
+           starts_with_list?, should_preserve_complete_structure?,
+           only_keep_first_sentence, remove_see_content,
+           remove_redundant_note, remove_invalid_references,
+           compare_with_definitions, REDUNDANT_NOTE_REGEX
+
+Suma::UrnMention (shared helper module)
+  ├─ express_reference_to_mention(description)
+  ├─ convert_express_xref(content, _schema_domain)
+  └─ urn_mention, term_urn, express_entity_urn (already on TermExtractor
+    via the Urn value object — relocate here)
+```
+
+`UrnMention` is a module so both `TermExtractor` (for definitions) and
+`NoteExtractor` (for trim_definition's final stage and for
+convert_express_xref) can include it without coupling to each other.
+
+## Public API
+
+```ruby
+module Suma
+  class NoteExtractor
+    def initialize(urn_mention:)            # injected collaborator
+      @urn_mention = urn_mention
+    end
+
+    # Returns [] if there are no usable notes after cleaning.
+    def extract(remarks:, schema_domain:, definition:) ...
+  end
+end
+```
+
+TermExtractor wires it up:
+
+```ruby
+def build_localized_concept(...)
+  ...
+  notes = NoteExtractor.new(urn_mention: method(:urn_mention))
+    .extract(remarks: entity.remarks,
+             schema_domain: schema_domain,
+             definition: data.definition.first&.content)
+  data.notes = notes if notes&.any?
+  ...
+end
+```
+
+Or pass a small collaborator object instead of a method reference.
+
+## Method inventory (what moves where)
+
+### Moves to NoteExtractor (private)
+
+- `REDUNDANT_NOTE_REGEX` constant
+- `get_entity_notes` (becomes `extract`)
+- `trim_definition`
+- `apply_first_sentence_logic`
+- `extract_complete_list`
+- `is_list_continuation?`
+- `starts_with_list?`
+- `should_preserve_complete_structure?`
+- `only_keep_first_sentence`
+- `remove_see_content`
+- `remove_redundant_note`
+- `remove_invalid_references`
+- `compare_with_definitions`
+
+### Moves to UrnMention module
+
+- `express_reference_to_mention`
+- `convert_express_xref`
+
+### Stays in TermExtractor
+
+- Manifest loading (`get_exp_files`)
+- `extract(exp_file)` orchestration
+- `build_managed_concept_collection`
+- `build_localized_concept`
+- `get_entity_terms`
+- `get_entity_definitions`
+- `generate_entity_definition`
+- `get_source_ref`, `get_section_ref`, `build_custom_locality`
+- `schema_urn`, `term_urn`, `express_entity_urn`, `urn_mention`
+- `extract_file_type`
+- `get_domain`
+- `entity_name_to_text`
+- `output_data`
+
+Net: TermExtractor shrinks from 462 → ~260 lines. NoteExtractor is
+~200 lines of focused prose-cleaning.
+
+## Files
+
+- `lib/suma/note_extractor.rb` — new class.
+- `lib/suma/urn_mention.rb` — new module (or `lib/suma/term_extractor/urn_mention.rb`
+  if you prefer namespacing).
+- `lib/suma/term_extractor.rb` — delete moved methods, wire up
+  NoteExtractor and include UrnMention.
+- `lib/suma.rb` — add autoloads for `NoteExtractor` and `UrnMention`.
+
+## Spec requirements
+
+This is a pure refactor — existing TermExtractor specs must pass
+unchanged. The work is *adding* NoteExtractor specs that lock in the
+cleaning rules.
+
+### `spec/suma/note_extractor_spec.rb`
+
+Cover every code path with real Annotated EXPRESS fixtures, not doubles:
+
+**trim_definition input shapes:**
+- Single-paragraph remark → first-sentence extraction
+- Multi-paragraph remark, first paragraph ends with ":" + list body →
+  list is preserved (first_paragraph + complete_list)
+- Multi-paragraph remark, first paragraph ends with ":" + non-list body →
+  first-sentence of first paragraph only
+- Empty array → []
+- nil → []
+- String instead of Array → handled
+- Remark with `//` Liquid-style comments → stripped
+- Remark with `<<express:foo.bar>>` xref → converted to urn mention
+
+**extract_complete_list:**
+- List with continuation markers (`+`)
+- List with `--` open/close delimiters
+- List with nested indentation (`^\s{2,}`)
+- List terminated by a non-list paragraph
+- List at end of remarks (no terminator)
+
+**only_keep_first_sentence:**
+- Note with `:\n` followed by list → preserved (NOT first-sentence extracted)
+- Note with period inside first paragraph → first-sentence logic applied
+- nil content → preserved (no crash)
+
+**remove filters:**
+- `remove_see_content` strips ` (see ...)` phrases
+- `remove_redundant_note` rejects "An X is a type of {{...}}" patterns
+  unless they contain newlines
+- `remove_invalid_references` rejects notes with `image::` or `<<...>>`
+- `compare_with_definitions` returns [] when note matches the definition
+
+**integration:**
+- A real Annotated EXPRESS fixture (use `action_schema` from
+  `spec/fixtures/extract_terms/resources/`) processed through NoteExtractor
+  produces the same array of DetailedDefinition objects that the current
+  TermExtractor produces. This is the regression guard.
+
+### `spec/suma/urn_mention_spec.rb`
+
+- `<<express:schema.entity>>` → `{{<urn>,entity}}`
+- `<<express:schema.entity,display text>>` → `{{<urn>,display text}}`
+- Multiple xrefs in one string → all converted
+- Pathological inputs (the ones from the CodeQL ReDoS fix) → no
+  catastrophic backtracking; fail fast
+
+## Acceptance criteria
+
+- `bundle exec rspec` passes unchanged (290 examples)
+- New `spec/suma/note_extractor_spec.rb` covers every method
+- New `spec/suma/urn_mention_spec.rb` covers the two mention helpers
+- TermExtractor is < 300 lines
+- No doubles in any new spec (per codebase rule)
+- No `require_relative` in new files (autoload only)
+- No `send` / `instance_variable_set` / `respond_to?` in new code
+- `bundle exec rubocop` clean
+
+## Out of scope
+
+- Extracting `DefinitionBuilder` for `generate_entity_definition` —
+  deferred to a follow-up. Definition generation has fewer methods and
+  is less pressing.
+- Refactoring `extract_file_type` (a string-classification helper) into
+  the existing `ExpressSchema::Type` — the two classify different things
+  (file suffix vs schema identity); don't conflate.
+
+## Suggested PR scope
+
+Single PR, three commits:
+
+1. `refactor: extract Suma::UrnMention module for express-xref → urn-mention conversion`
+2. `refactor: extract Suma::NoteExtractor from TermExtractor`
+3. `test: add comprehensive NoteExtractor and UrnMention specs`
+
+Three commits because (1) and (2) are sequential dependencies for (3),
+and (1) is independently useful even if (2) is deferred.
+
+## Risk
+
+Behavior must be byte-identical. The integration test in
+`spec/suma/note_extractor_spec.rb` (real action_schema fixture through
+the pipeline) is the regression guard — without it, this refactor is
+unsafe. Land specs in the same PR.

--- a/TODO.update/06-collapse-double-thor.md
+++ b/TODO.update/06-collapse-double-thor.md
@@ -1,0 +1,253 @@
+# TODO.update/06 — Collapse the double-Thor CLI pattern into Thor subcommands
+
+> Source: v0.3.0 audit follow-up. Large; separate PR.
+> This is the structural fix for the class of bug that PR #96 patched
+> symptomatically.
+
+## Current state
+
+`lib/suma/cli.rb` defines `Suma::Cli::Core < Thor` with one `desc`/`def`
+pair per subcommand. Each `def` body delegates to a separate Thor
+subclass by calling `Cli::<Name>.start(args)`:
+
+```ruby
+module Suma
+  module Cli
+    class Core < Thor
+      desc "extract-terms SCHEMA_MANIFEST_FILE GLOSSARIST_OUTPUT_PATH",
+           "Extract EXPRESS entity concepts ..."
+      option :urn, ...        # ← PR #96 added: options must be declared here too
+      option :language_code, ...
+      def extract_terms(*args)
+        Cli::ExtractTerms.start(args)   # ← inner Thor reparses ARGV
+      end
+
+      # ... 8 more delegations
+    end
+  end
+end
+```
+
+Each inner class (`Cli::ExtractTerms < Thor`, `Cli::Compare < Thor`, …)
+lives in its own file under `lib/suma/cli/`.
+
+## Problem
+
+This is the "double-Thor" pattern. Thor parses ARGV twice:
+
+1. `Core` parses it first (with `check_unknown_options!` enabled via
+   `ThorExt::Start`).
+2. If `Core` accepts the parse, it delegates to the inner Thor, which
+   reparses the same ARGV with its own option declarations.
+
+Any option declared only on the inner Thor is unknown to Core and gets
+rejected. PR #96 fixed this for `extract-terms` and `generate-register`
+by duplicating the option declarations onto `Core`. The fix is
+symptomatic — every other inner Thor command with options has the same
+bug latent.
+
+The PR #96 description itself flags this:
+
+> Out of scope (follow-up): the other inner-Thor commands (`build`,
+> `reformat`, `convert-jsdai`, `export`, `compare`) likely have the same
+> bug if they take options. Worth auditing in a separate PR if any of
+> them have inner-class options.
+
+This is that follow-up.
+
+## Proposed change
+
+Use Thor's built-in `subcommand` feature. `Core` becomes a thin
+register of subcommands; each `Cli::<Name>` keeps its `desc`/`option`
+declarations exactly once.
+
+```ruby
+module Suma
+  module Cli
+    class Core < Thor
+      # ThorExt::Start enhancements remain at this level
+      def self.start(args = ARGV, ...)
+        super
+      end
+
+      desc "version", "Print suma version"
+      def version
+        say Suma::VERSION
+      end
+
+      # Every former delegation becomes a one-line subcommand registration.
+      subcommand "build",            Suma::Cli::Build
+      subcommand "convert-jsdai",    Suma::Cli::ConvertJsdai
+      subcommand "extract-terms",    Suma::Cli::ExtractTerms
+      subcommand "generate-register", Suma::Cli::GenerateRegister
+      subcommand "generate-schemas", Suma::Cli::GenerateSchemas
+      subcommand "reformat",         Suma::Cli::Reformat
+      subcommand "compare",          Suma::Cli::Compare
+      subcommand "export",           Suma::Cli::Export
+      subcommand "validate",         Suma::Cli::Validate
+      subcommand "check-svg-quality", Suma::Cli::CheckSvgQuality
+      subcommand "expressir",        Suma::Cli::Expressir
+    end
+  end
+end
+```
+
+Each `Cli::<Name>` is already a Thor subclass. With subcommand
+registration, the only thing that changes is:
+
+1. Each inner class promotes its command from a method to the class
+   default command (so `suma extract-terms foo bar` invokes the inner
+   class's default command).
+2. Drop the wrapper `def extract_terms(*args); Cli::ExtractTerms.start(args); end`
+3. Drop the duplicated `option` declarations on Core (PR #96's patch).
+4. Drop the inner-class `.start` calls.
+
+Two equivalent ways to make the inner class invokable as a subcommand:
+
+### Option A: `default_command` (one command per inner class)
+
+Each inner class declares its single command and sets it as default:
+
+```ruby
+class ExtractTerms < Thor
+  default_command :extract_terms
+
+  desc "extract_terms SCHEMA_MANIFEST_FILE GLOSSARIST_OUTPUT_PATH",
+       "Extract EXPRESS entity concepts ..."
+  option :urn, ...
+  option :language_code, ...
+  def extract_terms(...)
+    Suma::TermExtractor.new(...).call
+  end
+end
+```
+
+Now `suma extract-terms foo bar --urn x` invokes
+`Cli::ExtractTerms#extract_terms` directly.
+
+### Option B: namespace + invoke
+
+Thor supports namespaced subcommands with multiple commands per
+subcommand. Heavier; not needed here.
+
+**Recommendation: Option A** — every inner class already has exactly one
+command. `default_command` is the minimal change.
+
+## Migration plan
+
+One PR, file-by-file. Order matters because Core must keep working at
+every commit.
+
+1. Convert each inner class to use `default_command`. Pure addition
+   (existing `.start` API still works). One commit per class or all
+   at once.
+2. Update `lib/suma/cli.rb` (Core) — replace each `desc/def` pair with
+   `subcommand "name", Cli::Name`. Drop duplicated `option` declarations.
+3. Update `lib/suma/cli/core.rb` if it has any dispatch logic (it
+   doesn't currently — it's mostly `ThorExt::Start`).
+4. Update `exe/suma` if it does anything beyond `Suma::Cli::Core.start`.
+
+## Files
+
+- `lib/suma/cli.rb` — rewrite Core as a subcommand register.
+- `lib/suma/cli/build.rb`, `compare.rb`, `convert_jsdai.rb`,
+  `export.rb`, `extract_terms.rb`, `generate_register.rb`,
+  `generate_schemas.rb`, `reformat.rb`, `validate.rb`,
+  `validate_links.rb`, `check_svg_quality.rb` — add `default_command`,
+  remove any PR #96-era workaround code.
+- `lib/suma/cli/core.rb` — verify `ThorExt::Start` integration still
+  works with subcommands.
+- `exe/suma` — likely unchanged.
+
+## Spec requirements
+
+There is currently no end-to-end CLI spec. The existing CLI specs
+invoke `described_class.new.invoke(:command, args, opts)`, which
+exercises the inner classes directly. After the refactor, those specs
+continue to work.
+
+Add a new `spec/suma/cli/core_spec.rb` that exercises Core as a user
+would, to lock in the subcommand dispatch contract:
+
+- `suma extract-terms --urn x foo bar` parses correctly through Core
+- `suma extract-terms --unknown-option` rejects the option at Core
+  (because the option isn't declared on ExtractTerms, not because of
+  duplicated declarations on Core)
+- `suma help extract-terms` shows the option (it doesn't need to be
+  re-declared on Core)
+- Every subcommand listed in `suma help` is invokable
+
+Use a real `Cli::Core.new.invoke(:extract_terms, ...)` — no doubles.
+
+## Acceptance criteria
+
+- `lib/suma/cli.rb` (Core) has zero `option` declarations and zero
+  `def <command>(*args); ... end` delegations
+- Every inner class has `default_command :<name>` and its own `option`s
+- `suma extract-terms --urn x ...`, `suma generate-register --urn ...`,
+  and every other documented CLI invocation works as documented
+- `suma help` lists every subcommand
+- `suma help <subcommand>` shows the options for that subcommand
+- All existing specs pass
+- New `spec/suma/cli/core_spec.rb` covers the dispatch contract
+
+## Risks
+
+- **Help output changes shape.** Thor's `subcommand` produces slightly
+  different help text than flat `desc`. Anyone parsing `suma help`
+  output (CI scripts?) needs to verify.
+- **Option precedence.** Global options on Core (`--help`) might
+  interact with subcommand options. Verify in specs.
+- **`ThorExt::Start` integration.** The custom `-h`/`--help` handling
+  in ThorExt was written for the flat pattern; verify it still fires
+  for subcommands.
+
+## Out of scope
+
+- Splitting `Suma::Cli::Validate` (currently a dispatcher to
+  `ValidateLinks`) into a proper subcommand namespace — this resolves
+  naturally once Validate is registered as a subcommand.
+- Removing inner Thor classes that don't add value (some are thin
+  shells around a service) — separate cleanup.
+
+## Suggested PR scope
+
+Single PR, three commits:
+
+1. `refactor: declare default_command on each Cli::<Name> subclass`
+2. `refactor: replace Cli::Core delegations with Thor subcommands`
+3. `test: add spec/suma/cli/core_spec.rb for subcommand dispatch`
+
+(1) and (2) are sequenced. (3) lands with (2) ideally; if review
+requests it, (3) can precede (2) as a "characterisation test"
+capturing current behavior, then (2) verifies it still passes.
+
+## Pre-reqs
+
+- PR #96 (which patched the symptomatic option-duplication) is already
+  merged. This refactor subsumes PR #96's patches — they'll be removed.
+- No dependency on TODO.update/03, 04, or 05.
+
+## Post-merge
+
+The "double-Thor" bug class is gone. New CLI commands declare their
+options once. Adding a command becomes:
+
+```ruby
+class Cli::NewThing < Thor
+  default_command :new_thing
+  desc "new_thing PATH", "Do the thing"
+  option :flag, type: :boolean
+  def new_thing(path)
+    Suma::NewThingService.new(path, flag: options[:flag]).call
+  end
+end
+```
+
+```ruby
+# lib/suma/cli.rb — one line:
+subcommand "new-thing", Suma::Cli::NewThing
+```
+
+No duplication, no second parse, no chance of Core rejecting options
+it doesn't know about.

--- a/TODO.update/README.md
+++ b/TODO.update/README.md
@@ -1,0 +1,85 @@
+# TODO.update
+
+Next-round refactor plans, sequenced by risk and dependency. Each file
+is sized to one focused PR.
+
+| # | File | Scope | Size | Risk |
+|---|------|-------|------|------|
+| 03 | [drop-redundant-schema-name-to-docs](03-drop-redundant-schema-name-to-docs.md) | Remove duplicate `@schema_name_to_docs` hash in SchemaCollection | XS | None |
+| 04 | [processor-configurable-paths](04-processor-configurable-paths.md) | Promote Processor's hardcoded paths to constructor kwargs | S | None (backwards-compatible) |
+| 05 | [extract-note-extractor](05-extract-note-extractor.md) | Split prose-cleaning logic out of TermExtractor into NoteExtractor + UrnMention | M | Behavioral — needs spec coverage landed in same PR |
+| 06 | [collapse-double-thor](06-collapse-double-thor.md) | Replace double-Thor CLI dispatch with Thor `subcommand` | M | Help-output shape change; verify ThorExt integration |
+
+The numbering starts at 03 to follow on from the v0.3.0 audit's
+"Suggested next actions" list (where 1 and 2 were contributor-PR actions
+on #95 and #35, not local refactors).
+
+## Dependency graph
+
+```
+03 → standalone (5-line change, do first as a warmup)
+04 → standalone (backwards-compatible)
+05 → standalone (own specs land in same PR)
+06 → standalone (post-PR-96 follow-up)
+```
+
+None of these block each other. They can land in parallel if reviewers
+are available, or serially in numerical order.
+
+## Recommended execution order
+
+1. **03** first — trivially safe, takes 5 minutes, removes a real
+   correctness footgun (the duplicate hash can drift).
+2. **04** next — small, backwards-compatible, enables Processor
+   end-to-end specs which the codebase currently lacks.
+3. **05** is the highest-payoff refactor: TermExtractor is the most
+   complex class in the codebase and the prose-cleaning pipeline is
+   the bulk of that complexity. Specs locked in first via integration
+   test against `action_schema` fixture.
+4. **06** last — touches every CLI file and changes `suma help` output.
+   Worth its own PR with a characterisation test.
+
+## What's not here
+
+These items were considered and deferred:
+
+- **Suma::Config value object** — only worth doing if configuration
+  surface grows. Right now env vars (SUMA_DEBUG, SUMA_SCHEMA_CACHE_DIR
+  post-#95) and constructor kwargs are manageable.
+- **SchemaCompiler dependency injection of Metanorma::Compile** — the
+  current direct invocation is fine; DI would add complexity without
+  enabling tests we don't already have.
+- **Parallel SchemaCollection#compile** — Ractor/thread pool. The
+  stale `feature/performance-next` branch tried this and reverted;
+  needs a separate investigation before committing.
+- **Suma::NoteExtractor → further split into SentenceExtractor +
+  ListExtractor + ReferenceFilter** — over-engineering for the current
+  complexity. One NoteExtractor class is the right size.
+
+## PR conventions
+
+Each plan follows:
+
+- **Current state** — what the code looks like today
+- **Problem** — why it needs to change, with concrete examples
+- **Proposed change** — what the new shape is
+- **Files** — exhaustive list of touched files
+- **Spec requirements** — what specs must exist (new or preserved)
+- **Acceptance criteria** — grep-able checks
+- **Out of scope** — what explicitly not to do
+- **Suggested PR scope** — commit structure
+
+If a plan is missing any of these, that's a bug in the plan.
+
+## Code-style invariants (apply to every PR in this directory)
+
+- Ruby `autoload` only; no `require_relative` in `lib/`
+- No `send` to call private methods
+- No `instance_variable_set` / `instance_variable_get`
+- No `respond_to?` for type checks
+- No doubles in specs; use real instances, `Struct`, or `Class.new`
+- `Utils.log` writes to `$stderr`; debug level gated by `SUMA_DEBUG`
+- Every new public method gets a spec; every behavioral edge case is covered
+- `frozen_string_literal: true` in every file
+- Rubocop clean (refresh `.rubocop_todo.yml` via
+  `rubocop -A --auto-gen-config` before merge)


### PR DESCRIPTION
Plans for items 03-06 from the v0.3.0 audit follow-up (see PR #91 and the audit posted on PR #95).

## Files added

- TODO.update/README.md — index, sequencing, code-style invariants
- TODO.update/03-drop-redundant-schema-name-to-docs.md — XS, safe
- TODO.update/04-processor-configurable-paths.md — S, backwards-compatible
- TODO.update/05-extract-note-extractor.md — M, ships with comprehensive specs
- TODO.update/06-collapse-double-thor.md — M, structural fix for the PR #96 bug class

## Why plans, not code

Each plan is sized to its own focused PR. Landing them all in one mega-PR would entangle four independent concerns and make review painful. The plans lock in:

- Current state (with line numbers)
- Problem statement (with concrete examples)
- Proposed change (with code sketches)
- File list (exhaustive)
- Spec requirements (with fixture guidance)
- Acceptance criteria (grep-able checks)
- Out of scope (what explicitly not to do)
- Suggested commit structure

The TODO.update directory is intentional planning (not scratch), so it is NOT in .gitignore alongside TODO.clean/, TODO.cleanup/, TODO.refactor/, TODO.remaining/.

## What was considered and deferred

Documented in the README: Suma::Config value object, SchemaCompiler DI for Metanorma::Compile, parallel SchemaCollection compile, over-fine NoteExtractor split.

## Test plan

- [x] Files render as markdown
- [x] CI green (docs-only change)