### PR TITLE
Deepen shallow modules behind clean seams (architecture review)

### DIFF
--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -11,6 +11,7 @@ module Suma
   autoload :CollectionConfig,       "suma/collection_config"
   autoload :CollectionManifest,     "suma/collection_manifest"
   autoload :EengineConverter,       "suma/eengine_converter"
+  autoload :ExpressReformatter,     "suma/express_reformatter"
   autoload :ExpressSchema,          "suma/express_schema"
   autoload :LinkValidation,         "suma/link_validation"
   autoload :LinkValidator,          "suma/link_validator"

--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -2,6 +2,7 @@
 
 require "expressir"
 require "lutaml/model"
+require "fileutils"
 
 module Suma
   autoload :VERSION, "suma/version"
@@ -11,6 +12,7 @@ module Suma
   autoload :CollectionManifest,     "suma/collection_manifest"
   autoload :EengineConverter,       "suma/eengine_converter"
   autoload :ExpressSchema,          "suma/express_schema"
+  autoload :LinkValidation,         "suma/link_validation"
   autoload :LinkValidator,          "suma/link_validator"
   autoload :ManifestTraverser,      "suma/manifest_traverser"
   autoload :RegisterManifestGenerator, "suma/register_manifest_generator"

--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -26,6 +26,7 @@ module Suma
   autoload :SchemaTemplate,         "suma/schema_template"
   autoload :SiteConfig,             "suma/site_config"
   autoload :SvgQuality,             "suma/svg_quality"
+  autoload :TermClassification,     "suma/term_classification"
   autoload :TermExtractor,          "suma/term_extractor"
   autoload :ThorExt,                "suma/thor_ext"
   autoload :Urn,                    "suma/urn"

--- a/lib/suma/cli/check_svg_quality.rb
+++ b/lib/suma/cli/check_svg_quality.rb
@@ -4,16 +4,19 @@ require "pathname"
 
 module Suma
   module Cli
-    # Check SVG quality using svg_conform Validator API - thin CLI wrapper
+    # Check SVG quality. Thin adapter around +Suma::SvgQuality::Scanner+:
+    # argument parsing, file discovery, sorting, filtering, output
+    # formatting. The deep scanner module owns validation orchestration
+    # and is reachable from specs without invoking Thor.
     class CheckSvgQuality
       DATA_PATH = "schemas"
       DEFAULT_PATTERN = "**/*.svg"
       DEFAULT_PROFILE = :metanorma
 
       def initialize(pattern: DEFAULT_PATTERN, profile: DEFAULT_PROFILE,
-                    format: "terminal", output: nil, min_errors: nil,
-                    summary_only: false, progress: false, limit: nil,
-                    sort: "errors")
+                     format: "terminal", output: nil, min_errors: nil,
+                     summary_only: false, progress: false, limit: nil,
+                     sort: "errors")
         @options = {
           pattern: pattern,
           profile: profile,
@@ -31,63 +34,16 @@ module Suma
         require "svg_conform"
 
         path_obj = Pathname.new(path).expand_path
-
-        # Enable progress by default when outputting to terminal
         show_progress = options[:progress] || ($stdout.tty? && !options[:output])
-        if show_progress
-          $stdout.sync = true
-          $stderr.sync = true
-        end
+        sync_stdio! if show_progress
 
-        if path_obj.file?
-          # Single file mode - show detailed errors
-          analyze_single_file(path_obj)
+        files = discover_files(path_obj)
+        return if files.empty?
+
+        if single_file?(path_obj, files)
+          print_single_report(scan_single(files.first))
         else
-          # Directory mode - show batch report
-          svg_files = find_svg_files(path_obj)
-
-          if svg_files.empty?
-            puts "No SVG files found in #{path}"
-            return
-          end
-
-          puts "🔍 Scanning #{svg_files.size} SVG files..."
-          puts
-
-          reports = analyze_files_one_by_one(svg_files, show_progress)
-          batch_report = SvgQuality::BatchReport.new(reports)
-          sorted_report = sort_report(batch_report)
-          output_report(sorted_report)
-        end
-      end
-
-      def analyze_single_file(path)
-        validator = SvgConform::Validator.new
-        result = validator.validate_file(path.to_s, profile: options[:profile])
-
-        puts "📄 SVG Quality Report: #{path}"
-        puts ""
-        puts "  Valid: #{result.valid? ? 'YES ✅' : 'NO ❌'}"
-        puts "  Errors: #{result.error_count}"
-        puts ""
-
-        if result.errors.any?
-          puts "  📋 Error Details"
-          puts ""
-
-          # Group errors by requirement_id
-          by_req = result.errors.group_by(&:requirement_id)
-
-          by_req.each do |req_id, errors|
-            puts "  #{req_id} (#{errors.size} occurrences)"
-            errors.first(5).each do |e|
-              puts "    - #{e.message}"
-            end
-            if errors.size > 5
-              puts "    ... and #{errors.size - 5} more"
-            end
-            puts ""
-          end
+          scan_and_output(files, show_progress)
         end
       end
 
@@ -95,7 +51,25 @@ module Suma
 
       attr_reader :options
 
-      def find_svg_files(path)
+      def single_file?(path_obj, files)
+        path_obj.file? && files.size == 1
+      end
+
+      def scan_and_output(files, show_progress)
+        puts "🔍 Scanning #{files.size} SVG files..." if show_progress
+        batch = SvgQuality::Scanner.new(
+          profile: options[:profile],
+          progress: progress_adapter(show_progress),
+        ).scan(files)
+        output_report(sort_report(batch))
+      end
+
+      def sync_stdio!
+        $stdout.sync = true
+        $stderr.sync = true
+      end
+
+      def discover_files(path)
         if path.directory?
           Pathname.glob(path.join(options[:pattern])).select(&:file?)
         elsif path.file? && path.extname == ".svg"
@@ -105,34 +79,47 @@ module Suma
         end
       end
 
-      def analyze_files_one_by_one(files, show_progress = false)
-        validator = SvgConform::Validator.new
-        reports = []
+      def scan_single(path)
+        SvgQuality::Scanner.new(profile: options[:profile]).scan_file(path)
+      end
 
-        files.each_with_index do |file, index|
-          result = validator.validate_file(file.to_s,
-                                           profile: options[:profile])
-          report = SvgQuality::Report.new(file.to_s, result)
-          reports << report
+      def print_single_report(report)
+        result = report
+        puts "📄 SVG Quality Report: #{result.file_path}"
+        puts ""
+        puts "  Valid: #{result.valid? ? 'YES ✅' : 'NO ❌'}"
+        puts "  Errors: #{result.error_count}"
+        puts ""
 
-          if show_progress
-            tier = report.quality_tier
-            status = report.valid? ? "✅" : "❌"
-            msg = "  [#{index + 1}/#{files.size}] #{tier[:emoji]} #{report.error_count} errors #{status} #{shorten_path(file)}\n"
-            $stderr.print msg
-            $stderr.flush
-          end
+        return unless result.errors.any?
+
+        puts "  📋 Error Details"
+        puts ""
+        by_req = result.errors.group_by(&:requirement_id)
+        by_req.each do |req_id, errors|
+          puts "  #{req_id} (#{errors.size} occurrences)"
+          errors.first(5).each { |e| puts "    - #{e.message}" }
+          puts "    ... and #{errors.size - 5} more" if errors.size > 5
+          puts ""
         end
+      end
 
-        reports
+      def progress_adapter(enabled)
+        return SvgQuality::Scanner::NullProgress.new unless enabled
+
+        ->(_index, _total, report) do
+          tier = report.quality_tier
+          status = report.valid? ? "✅" : "❌"
+          $stderr.print "  #{tier[:emoji]} #{report.error_count} errors " \
+                        "#{status} #{shorten_path(report.file_path)}\n"
+          $stderr.flush
+        end
       end
 
       def sort_report(batch_report)
         case options[:sort]
-        when :quality
-          batch_report.sort_by_quality
-        else
-          batch_report.sort_by_errors
+        when :quality then batch_report.sort_by_quality
+        else batch_report.sort_by_errors
         end
       end
 
@@ -140,19 +127,23 @@ module Suma
         filtered = batch_report.filter_by_min_errors(options[:min_errors])
         limited = filtered.limit(options[:limit])
 
-        formatter = case options[:format].to_sym
-                    when :json
-                      SvgQuality::Formatters::JsonFormatter.new(limited,
-                                                                output: options[:output])
-                    when :yaml
-                      SvgQuality::Formatters::YamlFormatter.new(limited,
-                                                                output: options[:output])
-                    else
-                      SvgQuality::Formatters::TerminalFormatter.new(limited,
-                                                                    output: options[:output], sort: options[:sort])
-                    end
-
+        formatter = formatter_for(limited)
         puts formatter.format
+      end
+
+      def formatter_for(batch_report)
+        case options[:format].to_sym
+        when :json
+          SvgQuality::Formatters::JsonFormatter.new(batch_report,
+                                                    output: options[:output])
+        when :yaml
+          SvgQuality::Formatters::YamlFormatter.new(batch_report,
+                                                    output: options[:output])
+        else
+          SvgQuality::Formatters::TerminalFormatter.new(batch_report,
+                                                        output: options[:output],
+                                                        sort: options[:sort])
+        end
       end
 
       def shorten_path(path)

--- a/lib/suma/cli/export.rb
+++ b/lib/suma/cli/export.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
 require "thor"
+require "pathname"
 
 module Suma
   module Cli
-    # Export command for exporting EXPRESS schemas from a manifest
+    # Export command. Thin Thor adapter that constructs
+    # +Suma::ExpressSchema+ instances from manifest entries or
+    # standalone +.exp+ files, then delegates the actual writing to
+    # +Suma::SchemaExporter+.
+    #
+    # The schema-type → output-subdirectory mapping lives in
+    # +Suma::SchemaCategory+, the single source of truth. The exporter
+    # itself never classifies — it consumes loaded ExpressSchema
+    # objects whose output paths were set by this adapter.
     class Export < Thor
       desc "export *FILES",
            "Export EXPRESS schemas from manifest files or " \
@@ -38,7 +47,7 @@ module Suma
       end
 
       def run(files, options)
-        schemas = load_schemas_from_files(files)
+        schemas = files.flat_map { |file| build_schemas(file) }
 
         exporter = SchemaExporter.new(
           schemas: schemas,
@@ -52,22 +61,12 @@ module Suma
         exporter.export
       end
 
-      def load_schemas_from_files(files)
-        all_schemas = []
-
-        files.each do |file|
-          all_schemas += process_file(file)
-        end
-
-        all_schemas
-      end
-
-      def process_file(file)
+      def build_schemas(file)
         case File.extname(file).downcase
         when ".yml", ".yaml"
-          load_manifest_schemas(file)
+          build_from_manifest(file)
         when ".exp"
-          [create_schema_from_exp_file(file)]
+          [build_standalone(file)]
         else
           raise ArgumentError, "Unsupported file type: #{file}. " \
                                "Only .yml, .yaml, and .exp files are " \
@@ -75,13 +74,32 @@ module Suma
         end
       end
 
-      def load_manifest_schemas(file)
+      def build_from_manifest(file)
         manifest = Expressir::SchemaManifest.from_file(file)
-        manifest.schemas
+        manifest.schemas.map { |entry| build_from_manifest_entry(entry) }
       end
 
-      def create_schema_from_exp_file(exp_file)
-        Struct.new(:id, :path).new(nil, File.expand_path(exp_file))
+      def build_from_manifest_entry(entry)
+        category = SchemaCategory.for_schema(id: entry.id, path: entry.path)
+        ExpressSchema.new(
+          id: entry.id,
+          path: entry.path.to_s,
+          output_path: output_root.join(category.directory).to_s,
+          is_standalone_file: false,
+        )
+      end
+
+      def build_standalone(exp_file)
+        ExpressSchema.new(
+          id: nil,
+          path: File.expand_path(exp_file),
+          output_path: output_root.to_s,
+          is_standalone_file: true,
+        )
+      end
+
+      def output_root
+        Pathname.new(options[:output]).expand_path
       end
 
       def self.exit_on_failure?

--- a/lib/suma/cli/reformat.rb
+++ b/lib/suma/cli/reformat.rb
@@ -4,84 +4,60 @@ require "thor"
 
 module Suma
   module Cli
-    # Reformat command for reformatting EXPRESS files
+    # Reformat command for reformatting EXPRESS files.
+    #
+    # Thin Thor adapter around Suma::ExpressReformatter: argument
+    # parsing, file discovery, and read/transform/write. The content
+    # transformation itself lives in the deep module and is tested
+    # independently.
     class Reformat < Thor
-      desc "reformat EXPRESS_FILE_PATH",
-           "Reformat EXPRESS files"
+      desc "reformat EXPRESS_FILE_PATH", "Reformat EXPRESS files"
       option :recursive, type: :boolean, default: false, aliases: "-r",
                          desc: "Reformat EXPRESS files under the specified " \
                                "path recursively"
 
-      def reformat(express_file_path) # rubocop:disable Metrics/AbcSize
-        if File.file?(express_file_path)
-          unless File.exist?(express_file_path)
-            raise Errno::ENOENT, "Specified EXPRESS file " \
-                                 "`#{express_file_path}` not found."
-          end
-
-          if File.extname(express_file_path) != ".exp"
-            raise ArgumentError, "Specified file `#{express_file_path}` is " \
-                                 "not an EXPRESS file."
-          end
-
-          exp_files = [express_file_path]
-        elsif options[:recursive]
-          exp_files = Dir.glob("#{express_file_path}/**/*.exp")
-        else
-          exp_files = Dir.glob("#{express_file_path}/*.exp")
-        end
-
-        if exp_files.empty?
-          raise Errno::ENOENT, "No EXPRESS files found in " \
-                               "`#{express_file_path}`."
-        end
-
-        run(exp_files)
+      def reformat(express_file_path)
+        files = discover_files(express_file_path)
+        ensure_files_found!(files, express_file_path)
+        process_files(files)
       end
 
       private
 
-      def run(exp_files)
-        exp_files.each do |exp_file|
-          reformat_exp(exp_file)
-        end
+      def discover_files(path)
+        return [path] if File.file?(path)
+        return Dir.glob("#{path}/**/*.exp") if options[:recursive]
+
+        Dir.glob("#{path}/*.exp")
       end
 
-      def reformat_exp(file) # rubocop:disable Metrics/AbcSize
-        # Read the file content
-        file_content = File.read(file)
-
-        # Extract all comments between '(*"' and '\n*)'
-        # Avoid incorrect selection of some comment blocks
-        # containing '(*text*)' inside
-        comments = file_content.scan(/\(\*"(.*?)\n\*\)/m).map(&:first)
-
-        if comments.any?
-          content_without_comments = file_content.gsub(/\(\*".*?\n\*\)/m, "")
-
-          # remove extra newlines
-          new_content = content_without_comments.gsub(/(\n\n+)/, "\n\n")
-          # Add '(*"' and '\n*)' to enclose the comment block
-          new_comments = comments.map { |c| "(*\"#{c}\n*)" }.join("\n\n")
-          # Append the comments to the end of the file
-          new_content = "#{new_content}\n\n#{new_comments}\n"
-
-          # Compare the changes between the original content with the modified
-          # content, if the changes are just whitespaces, skip modifying the
-          # file
-          if file_content.gsub(/(\n+)/, "\n") == new_content.gsub(/(\n+)/, "\n")
-            puts "No changes made to #{file}"
-            return
+      def ensure_files_found!(files, path)
+        if File.file?(path)
+          unless File.extname(path) == ".exp"
+            raise ArgumentError,
+                  "Specified file `#{path}` is not an EXPRESS file."
           end
-
-          update_exp(file, new_content)
+        elsif !File.exist?(path)
+          raise Errno::ENOENT,
+                "Specified EXPRESS file `#{path}` not found."
         end
+        return unless files.empty?
+
+        raise Errno::ENOENT, "No EXPRESS files found in `#{path}`."
       end
 
-      def update_exp(file, content)
-        # Write the modified content to a new file
-        File.write(file, content)
-        puts "Reformatted EXPRESS file and saved to #{file}"
+      def process_files(files)
+        files.each { |file| reformat_one(file) }
+      end
+
+      def reformat_one(file)
+        result = ExpressReformatter.call(File.read(file))
+        if result.changed?
+          File.write(file, result.content)
+          puts "Reformatted EXPRESS file and saved to #{file}"
+        else
+          puts "No changes made to #{file}"
+        end
       end
     end
   end

--- a/lib/suma/cli/validate.rb
+++ b/lib/suma/cli/validate.rb
@@ -4,14 +4,23 @@ require "thor"
 
 module Suma
   module Cli
-    # Main validate command that groups the validation subcommands
+    # Validate command group. Thin Thor adapter around
+    # +Suma::LinkValidation+ — argument parsing, result presentation.
+    # All orchestration (manifest loading, link extraction, schema
+    # indexing, validation) lives in the deep module and is reachable
+    # from specs without invoking Thor.
     class Validate < Thor
       desc "links SCHEMAS_FILE DOCUMENTS_PATH [OUTPUT_FILE]",
            "Extract and validate express links without creating intermediate file"
-      def links(*args)
-        # Forward the command to ValidateLinks
-        links = Cli::ValidateLinks.new
-        links.extract_and_validate(*args)
+      def links(schemas_file = "schemas-srl.yml",
+                documents_path = "documents",
+                output_file = "validation_results.txt")
+        result = LinkValidation.new(
+          schemas_file: schemas_file,
+          documents_path: documents_path,
+          output_file: output_file,
+        ).call
+        puts LinkValidation.generate_summary(result)
       end
     end
   end

--- a/lib/suma/cli/validate_links.rb
+++ b/lib/suma/cli/validate_links.rb
@@ -1,168 +1,24 @@
 # frozen_string_literal: true
 
 require "thor"
-require "expressir"
 
 module Suma
   module Cli
+    # Deprecated: prefer +Cli::Validate#links+ (the +suma validate links+
+    # subcommand). This class is retained as a backwards-compat entry
+    # point — all orchestration now lives in +Suma::LinkValidation+.
     class ValidateLinks < Thor
       desc "extract_and_validate SCHEMAS_FILE DOCUMENTS_PATH [OUTPUT_FILE]",
            "Extract and validate express links without creating intermediate file"
       def extract_and_validate(schemas_file = "schemas-srl.yml",
-                              documents_path = "documents",
-                              output_file = "validation_results.txt")
-        load_dependencies
-        paths = prepare_file_paths(schemas_file, documents_path, output_file)
-
-        schemas_config = load_schemas_config(paths[:schemas_file])
-        exp_files = collect_schema_paths(schemas_config, paths[:schemas_file_rel])
-        adoc_files = find_adoc_files(paths[:documents_path])
-
-        all_files = adoc_files + exp_files
-        display_file_counts(adoc_files, exp_files)
-
-        links_by_file = extract_links(all_files)
-
-        repo = load_express_schemas(schemas_config)
-        index = SchemaIndex.new(repo)
-        unresolved = LinkValidator.new(index).validate(links_by_file)
-
-        write_validation_results(paths[:output_file], paths[:output_file_rel],
-                                 unresolved, links_by_file)
-      end
-
-      private
-
-      def load_dependencies
-        require "expressir"
-        require "ruby-progressbar"
-        require "pathname"
-      end
-
-      def prepare_file_paths(schemas_file, documents_path, output_file)
-        schemas_file_path = Pathname.new(schemas_file).expand_path
-        documents_path_exp = Pathname.new(documents_path).expand_path
-        output_file_path = Pathname.new(output_file).expand_path
-
-        schemas_file_rel = Pathname.new(schemas_file_path).relative_path_from(Pathname.pwd).to_s
-        documents_path_rel = Pathname.new(documents_path_exp).relative_path_from(Pathname.pwd).to_s
-        output_file_rel = Pathname.new(output_file_path).relative_path_from(Pathname.pwd).to_s
-
-        puts "Extracting and validating express links using schemas from #{schemas_file_rel}..."
-        puts "Looking for documents in #{documents_path_rel}..."
-
-        {
-          schemas_file: schemas_file_path,
-          schemas_file_rel: schemas_file_rel,
-          documents_path: documents_path_exp,
-          documents_path_rel: documents_path_rel,
-          output_file: output_file_path,
-          output_file_rel: output_file_rel,
-        }
-      end
-
-      def load_schemas_config(schemas_file_path)
-        schemas_config = Expressir::SchemaManifest.from_yaml(File.read(schemas_file_path))
-        schemas_config.set_initial_path(schemas_file_path.to_s)
-        schemas_config
-      rescue StandardError => e
-        raise Suma::Error, "Error loading schemas file: #{e.message}"
-      end
-
-      def collect_schema_paths(schemas_config, schemas_file_rel)
-        exp_files = schemas_config.schemas.filter_map(&:path)
-        puts "Found #{exp_files.size} EXPRESS schema files from #{schemas_file_rel}"
-        exp_files
-      end
-
-      def find_adoc_files(documents_path)
-        Dir.glob(documents_path.join("**", "*.adoc").to_s)
-      end
-
-      def display_file_counts(adoc_files, exp_files)
-        puts "Found #{adoc_files.size} AsciiDoc files and #{exp_files.size} EXPRESS files"
-      end
-
-      def create_progress_bar(title, total)
-        ProgressBar.create(
-          title: title,
-          total: total,
-          format: "%t: [%B] %p%% %c/%C %e",
-          progress_mark: "=",
-          remainder_mark: " ",
-          length: 80,
-        )
-      end
-
-      def extract_links(files)
-        links_by_file = {}
-        link_count = 0
-
-        progress = create_progress_bar("Processing files", files.size)
-
-        files.each do |file|
-          progress.increment
-          begin
-            content = File.read(file)
-            express_links = content.scan(/<<express:([^,>]+)(?:,[^>]+)?>>/).flatten.uniq
-
-            if express_links.any?
-              links_by_file[file] = express_links
-              link_count += express_links.size
-            end
-          rescue StandardError => e
-            puts "\nWarning: Could not read file #{file}: #{e.message}"
-          end
-        end
-
-        puts "\nExtracted #{link_count} unique express links from #{links_by_file.size} files"
-        links_by_file
-      end
-
-      def load_express_schemas(schemas_config)
-        schema_paths = {}
-        schemas_config.schemas.each { |s| schema_paths[s.id] = s.path }
-
-        puts "Loading #{schema_paths.size} EXPRESS schemas for validation..."
-
-        loading_progress = create_progress_bar("Loading schemas", schema_paths.size)
-
-        begin
-          repo = Expressir::Express::Parser.from_files(schema_paths.values) do |filename, _schemas, error|
-            loading_progress.increment
-            puts "\nWarning: Error loading schema #{filename}: #{error.message}" if error
-          end
-
-          puts "Successfully loaded #{repo.schemas.size} schemas"
-          repo
-        rescue StandardError => e
-          raise Suma::Error, "Error loading schemas: #{e.message}"
-        end
-      end
-
-      def write_validation_results(output_file_path, output_file_rel,
-  unresolved_links, links_by_file)
-        total_links = links_by_file.values.sum(&:size)
-
-        results = []
-        results << "Validation complete. Checked #{total_links} links."
-
-        if unresolved_links.empty?
-          results << "✅ All links resolved successfully!"
-        else
-          results << "❌ Found #{unresolved_links.size} unresolved links:"
-          unresolved_links.each do |issue|
-            results << "#{issue.file}:#{issue.line} - <<express:#{issue.link}>> - #{issue.reason}"
-          end
-        end
-
-        begin
-          File.write(output_file_path, results.join("\n"))
-          puts "Validation results written to #{output_file_rel}"
-        rescue StandardError => e
-          puts "Error writing to output file: #{e.message}"
-          puts results
-        end
+                               documents_path = "documents",
+                               output_file = "validation_results.txt")
+        result = LinkValidation.new(
+          schemas_file: schemas_file,
+          documents_path: documents_path,
+          output_file: output_file,
+        ).call
+        puts LinkValidation.generate_summary(result)
       end
     end
   end

--- a/lib/suma/express_reformatter.rb
+++ b/lib/suma/express_reformatter.rb
@@ -11,6 +11,12 @@ module Suma
   #
   # The transform is idempotent: reformatting an already-reformatted
   # document returns +changed?: false+.
+  #
+  # Comment extraction uses +String#index+ rather than a single m-mode
+  # regex. The original +/\(\*"(.*?)\n\*\)/m+ is correct functionally
+  # but is polynomial-time on adversarial input (CodeQL
+  # +rb/polynomial-redos+). Scanning for the start marker, then for
+  # the next terminator, is unambiguously linear.
   module ExpressReformatter
     Result = Struct.new(:content, :changed?, keyword_init: true) do
       def content_or_nil
@@ -18,27 +24,65 @@ module Suma
       end
     end
 
-    COMMENT_PATTERN = /\(\*"(.*?)\n\*\)/m
+    COMMENT_START = '(*"'
+    COMMENT_END = "\n*)"
     BLANK_RUN_PATTERN = /(\n\n+)/
     NEWLINE_RUN_PATTERN = /(\n+)/
 
     module_function
 
     def call(content)
-      comments = content.scan(COMMENT_PATTERN).map(&:first)
+      comments = extract_comments(content)
       return Result.new(content: content, changed?: false) if comments.empty?
 
-      without_comments = content.gsub(COMMENT_PATTERN, "")
-      new_comments = comments.map { |c| "(*\"#{c}\n*)" }.join("\n\n")
-      # Assemble first, then collapse blank-line runs — so the seam
-      # between body and appended comments is normalised along with
-      # everything else. Doing it before assembly leaves a 3+ newline
-      # boundary that breaks idempotence on the second pass.
+      without_comments = strip_comments(content)
+      new_comments = comments.map { |c| "#{COMMENT_START}#{c}#{COMMENT_END}" }
+        .join("\n\n")
       new_content = "#{without_comments}\n\n#{new_comments}\n"
       new_content = new_content.gsub(BLANK_RUN_PATTERN, "\n\n")
 
       changed = normalised_compare(content, new_content) != 0
       Result.new(content: new_content, changed?: changed)
+    end
+
+    def extract_comments(content)
+      comments = []
+      pos = 0
+      while (start_idx = content.index(COMMENT_START, pos))
+        end_idx = content.index(COMMENT_END, start_idx + COMMENT_START.length)
+        break unless end_idx
+
+        comments << content[(start_idx + COMMENT_START.length)...end_idx]
+        pos = end_idx + COMMENT_END.length
+      end
+      comments
+    end
+
+    def strip_comments(content)
+      return content unless content.index(COMMENT_START, 0)
+
+      stripped = +""
+      last_end = 0
+      each_comment_range(content) do |range|
+        stripped << content[range[:pre_start]...range[:start]]
+        last_end = range[:end_exclusive]
+      end
+      stripped << content[last_end..]
+      stripped.force_encoding(content.encoding)
+    end
+
+    def each_comment_range(content)
+      return enum_for(:each_comment_range, content) unless block_given?
+
+      pos = 0
+      while (start_idx = content.index(COMMENT_START, pos))
+        end_idx = content.index(COMMENT_END, start_idx + COMMENT_START.length)
+        break unless end_idx
+
+        yield pre_start: pos, start: start_idx,
+              end_exclusive: end_idx + COMMENT_END.length
+        pos = end_idx + COMMENT_END.length
+      end
     end
 
     def normalised_compare(left, right)

--- a/lib/suma/express_reformatter.rb
+++ b/lib/suma/express_reformatter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Suma
+  # Reformats EXPRESS source into suma's canonical form: comment blocks
+  # (the +(*"...\n*)+ remarks that EXPRESS uses for documentation) are
+  # extracted from their inline positions and appended to the end of
+  # the file, and excess blank lines are collapsed.
+  #
+  # Pure content transformation — no I/O, no Thor, no filesystem. The
+  # CLI adapter handles reading from and writing to disk.
+  #
+  # The transform is idempotent: reformatting an already-reformatted
+  # document returns +changed?: false+.
+  module ExpressReformatter
+    Result = Struct.new(:content, :changed?, keyword_init: true) do
+      def content_or_nil
+        changed? ? content : nil
+      end
+    end
+
+    COMMENT_PATTERN = /\(\*"(.*?)\n\*\)/m
+    BLANK_RUN_PATTERN = /(\n\n+)/
+    NEWLINE_RUN_PATTERN = /(\n+)/
+
+    module_function
+
+    def call(content)
+      comments = content.scan(COMMENT_PATTERN).map(&:first)
+      return Result.new(content: content, changed?: false) if comments.empty?
+
+      without_comments = content.gsub(COMMENT_PATTERN, "")
+      new_comments = comments.map { |c| "(*\"#{c}\n*)" }.join("\n\n")
+      # Assemble first, then collapse blank-line runs — so the seam
+      # between body and appended comments is normalised along with
+      # everything else. Doing it before assembly leaves a 3+ newline
+      # boundary that breaks idempotence on the second pass.
+      new_content = "#{without_comments}\n\n#{new_comments}\n"
+      new_content = new_content.gsub(BLANK_RUN_PATTERN, "\n\n")
+
+      changed = normalised_compare(content, new_content) != 0
+      Result.new(content: new_content, changed?: changed)
+    end
+
+    def normalised_compare(left, right)
+      left.gsub(NEWLINE_RUN_PATTERN, "\n") <=> right.gsub(NEWLINE_RUN_PATTERN, "\n")
+    end
+
+    private_class_method :normalised_compare
+  end
+end

--- a/lib/suma/link_validation.rb
+++ b/lib/suma/link_validation.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "pathname"
+require "expressir"
+
+module Suma
+  # Deep module behind the EXPRESS cross-reference validation pipeline.
+  #
+  # Interface: paths in, +Result+ out. The CLI is a thin adapter that
+  # constructs this object and prints the result.
+  #
+  # Owns: loading the schemas manifest, discovering + reading .adoc and
+  # .exp files, extracting express cross-reference links, loading parsed
+  # schemas into a +SchemaIndex+, delegating to +LinkValidator+ for the
+  # actual resolution, and writing the summary file.
+  #
+  # Does not own: presentation (use +LinkValidation.generate_summary+),
+  # command-line argument parsing (the CLI adapter does that), or the
+  # link-resolution rules themselves (that is +LinkValidator+'s job).
+  class LinkValidation
+    EXPRESS_LINK_PATTERN = /<<express:([^,>]+)(?:,[^>]+)?>>/
+
+    attr_reader :schemas_file, :documents_path, :output_file,
+                :progress, :logger
+
+    def initialize(schemas_file:, documents_path:, output_file:,
+                   progress: NullProgress.new, logger: Utils)
+      @schemas_file = Pathname.new(schemas_file).expand_path
+      @documents_path = Pathname.new(documents_path).expand_path
+      @output_file = output_file && Pathname.new(output_file).expand_path
+      @progress = progress
+      @logger = logger
+    end
+
+    def call
+      config = load_schemas_config
+      exp_files = collect_schema_paths(config)
+      adoc_files = find_adoc_files
+      links_by_file = extract_links(adoc_files + exp_files)
+      unresolved = validate_links(config, links_by_file)
+      result = Result.new(
+        adoc_count: adoc_files.size,
+        exp_count: exp_files.size,
+        total_links: links_by_file.values.sum(&:size),
+        unresolved: unresolved,
+      )
+      write_summary(result) if output_file
+      result
+    end
+
+    def self.generate_summary(result)
+      lines = []
+      lines << "Validation complete. Checked #{result.total_links} links."
+      if result.success?
+        lines << "✅ All links resolved successfully!"
+      else
+        lines << "❌ Found #{result.unresolved.size} unresolved links:"
+        result.unresolved.each { |issue| lines << format_issue(issue) }
+      end
+      lines.join("\n")
+    end
+
+    def self.format_issue(issue)
+      "#{issue.file}:#{issue.line} - " \
+        "<<express:#{issue.link}>> - #{issue.reason}"
+    end
+    private_class_method :format_issue
+
+    # Default no-op progress adapter. Callers that want a real progress
+    # bar pass an object responding to +#start(title, total)+ and
+    # +#increment+; this satisfies the same interface without forcing
+    # the dependency.
+    class NullProgress
+      def start(_title, _total); end
+
+      def increment; end
+    end
+
+    Result = Struct.new(
+      :adoc_count,
+      :exp_count,
+      :total_links,
+      :unresolved,
+      keyword_init: true,
+    ) do
+      def success?
+        unresolved.empty?
+      end
+    end
+
+    private
+
+    def load_schemas_config
+      Expressir::SchemaManifest.from_yaml(File.read(schemas_file))
+        .tap { |c| c.set_initial_path(schemas_file.to_s) }
+    rescue StandardError => e
+      raise Error, "Error loading schemas file: #{e.message}"
+    end
+
+    def collect_schema_paths(schemas_config)
+      schemas_config.schemas.filter_map(&:path)
+    end
+
+    def find_adoc_files
+      Dir.glob(documents_path.join("**", "*.adoc").to_s)
+    end
+
+    def extract_links(files)
+      links_by_file = {}
+      progress.start("Processing files", files.size)
+      files.each do |file|
+        links = extract_links_from_file(file)
+        links_by_file[file] = links if links&.any?
+      end
+      links_by_file
+    end
+
+    def extract_links_from_file(file)
+      progress.increment
+      content = File.read(file)
+      content.scan(EXPRESS_LINK_PATTERN).flatten.uniq
+    rescue StandardError => e
+      logger.log "Warning: Could not read file #{file}: #{e.message}"
+      nil
+    end
+
+    def validate_links(schemas_config, links_by_file)
+      paths_by_id = schemas_config.schemas.to_h { |s| [s.id, s.path] }
+      progress.start("Loading schemas", paths_by_id.size)
+      repo = Expressir::Express::Parser.from_files(paths_by_id.values) do |*_args|
+        progress.increment
+      end
+      index = SchemaIndex.new(repo)
+      LinkValidator.new(index).validate(links_by_file)
+    end
+
+    def write_summary(result)
+      FileUtils.mkdir_p(output_file.dirname)
+      File.write(output_file, self.class.generate_summary(result))
+    rescue StandardError => e
+      logger.log "Error writing to output file: #{e.message}"
+    end
+  end
+end

--- a/lib/suma/link_validator.rb
+++ b/lib/suma/link_validator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "expressir"
+require "suma/link_validation"
 
 module Suma
   LinkValidationResult = Struct.new(:file, :line, :link, :reason,
@@ -28,7 +29,7 @@ module Suma
       content = File.read(file)
       index = {}
       content.lines.each_with_index do |line, idx|
-        line.scan(/<<express:([^,>]+)(?:,[^>]+)?>>/).flatten.each do |link|
+        line.scan(LinkValidation::EXPRESS_LINK_PATTERN).flatten.each do |link|
           index[link] ||= idx
         end
       end

--- a/lib/suma/schema_collection.rb
+++ b/lib/suma/schema_collection.rb
@@ -40,7 +40,7 @@ module Suma
       finalize
 
       exporter = SchemaExporter.new(
-        schemas: @config.schemas,
+        schemas: schemas.values,
         output_path: @output_path_schemas,
         options: { annotations: false },
       )

--- a/lib/suma/schema_exporter.rb
+++ b/lib/suma/schema_exporter.rb
@@ -3,8 +3,19 @@
 require "fileutils"
 
 module Suma
-  # SchemaExporter exports EXPRESS schemas from a manifest
-  # with configurable options for annotations and ZIP packaging
+  # Exports EXPRESS schemas to a directory, with optional ZIP packaging.
+  #
+  # Pure sink: the exporter accepts already-loaded +Suma::ExpressSchema+
+  # instances and writes their content to disk. Construction of those
+  # instances (with the right +output_path+ and +is_standalone_file+
+  # flags) is the caller's responsibility — the exporter does not
+  # reach across the seam to inspect manifest entries or classify
+  # schema types itself.
+  #
+  # This is a deep module: a small interface (one +export+ method, one
+  # option hash) backed by save_exp + zip packaging. The CLI and
+  # SchemaCollection adapters construct ExpressSchema instances; the
+  # exporter never inspects their shape.
   class SchemaExporter
     attr_reader :schemas, :output_path, :options
 
@@ -35,30 +46,7 @@ module Suma
 
     def export_to_directory(schemas)
       schemas.each do |schema|
-        export_single_schema(schema)
-      end
-    end
-
-    def export_single_schema(schema)
-      is_standalone = !schema.is_a?(Expressir::SchemaManifestEntry)
-      schema_output_path = determine_output_path(schema, is_standalone)
-
-      express_schema = ExpressSchema.new(
-        id: schema.id,
-        path: schema.path.to_s,
-        output_path: schema_output_path,
-        is_standalone_file: is_standalone,
-      )
-
-      express_schema.save_exp(with_annotations: options[:annotations])
-    end
-
-    def determine_output_path(schema, is_standalone)
-      if is_standalone
-        output_path.to_s
-      else
-        category = SchemaCategory.for_schema(id: schema.id, path: schema.path)
-        output_path.join(category.directory).to_s
+        schema.save_exp(with_annotations: options[:annotations])
       end
     end
 

--- a/lib/suma/svg_quality.rb
+++ b/lib/suma/svg_quality.rb
@@ -6,6 +6,7 @@ module Suma
   module SvgQuality
     autoload :Report,      "suma/svg_quality/report"
     autoload :BatchReport, "suma/svg_quality/batch_report"
+    autoload :Scanner,     "suma/svg_quality/scanner"
 
     module QualityTiers
       CRITICAL = { name: :critical, min_errors: 200, emoji: "💥" }.freeze

--- a/lib/suma/svg_quality/scanner.rb
+++ b/lib/suma/svg_quality/scanner.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "svg_conform"
+
+module Suma
+  module SvgQuality
+    # Deep module behind the SVG-quality seam: takes paths in, returns
+    # +Report+ / +BatchReport+ out. Owns validator construction and
+    # per-file result capture. Does not own file discovery, sorting,
+    # filtering, or presentation — those stay in the CLI adapter.
+    #
+    # The progress adapter is injected: pass any object responding to
+    # +#call(index, total, report)+. +NullProgress+ is the default
+    # no-op; the CLI passes a lambda that writes to +$stderr+.
+    class Scanner
+      DEFAULT_PROFILE = :metanorma
+
+      attr_reader :profile, :progress
+
+      def initialize(profile: DEFAULT_PROFILE,
+                     progress: NullProgress.new)
+        @profile = profile
+        @progress = progress
+      end
+
+      def scan(paths)
+        validator = build_validator
+        reports = paths.each_with_index.map do |path, index|
+          scan_one(validator, path, index, paths.size)
+        end
+        BatchReport.new(reports)
+      end
+
+      def scan_file(path)
+        Report.new(path.to_s, build_validator.validate_file(path.to_s,
+                                                            profile: profile))
+      end
+
+      # Default no-op progress adapter. Real progress reporters are
+      # passed by the caller; this satisfies the same interface so the
+      # scanner can be invoked from specs without forcing the
+      # dependency.
+      class NullProgress
+        def call(_index, _total, _report); end
+      end
+
+      private
+
+      def build_validator
+        SvgConform::Validator.new
+      end
+
+      def scan_one(validator, path, index, total)
+        result = validator.validate_file(path.to_s, profile: profile)
+        report = Report.new(path.to_s, result)
+        progress.call(index, total, report)
+        report
+      end
+    end
+  end
+end

--- a/lib/suma/term_classification.rb
+++ b/lib/suma/term_classification.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Suma
+  # Term-extractor-specific classification of an EXPRESS schema.
+  #
+  # Bridges ExpressSchema::Type (the canonical classification shared
+  # across the codebase) and the Glossarist-specific labels
+  # TermExtractor emits: the domain string ("application module" /
+  # "resource") that goes into a concept's +domain+ field, and the
+  # entity-type URN term used in generated concept definitions.
+  #
+  # The mapping is data — a frozen Hash keyed by ExpressSchema::Type
+  # symbol — so adding a new schema type is a one-line addition to
+  # BY_TYPE (open/closed principle). The previous implementation
+  # switched on string keys in three separate places; this consolidates
+  # them into one source of truth.
+  class TermClassification
+    attr_reader :type, :domain_label, :entity_term, :entity_display
+
+    def initialize(type:, domain_label:, entity_term:, entity_display:)
+      @type = type
+      @domain_label = domain_label
+      @entity_term = entity_term
+      @entity_display = entity_display
+      freeze
+    end
+
+    def domain_for(schema_id)
+      "#{domain_label}: #{schema_id}"
+    end
+
+    BY_TYPE = {
+      ExpressSchema::Type::RESOURCE => new(
+        type: ExpressSchema::Type::RESOURCE,
+        domain_label: "resource",
+        entity_term: "express-language.entity_data_type",
+        entity_display: "entity data type",
+      ),
+      ExpressSchema::Type::MODULE_ARM => new(
+        type: ExpressSchema::Type::MODULE_ARM,
+        domain_label: "application module",
+        entity_term: "general.application_object",
+        entity_display: "application object",
+      ),
+      ExpressSchema::Type::MODULE_MIM => new(
+        type: ExpressSchema::Type::MODULE_MIM,
+        domain_label: "application module",
+        entity_term: "express-language.entity_data_type",
+        entity_display: "entity data type",
+      ),
+      ExpressSchema::Type::BUSINESS_OBJECT_MODEL => new(
+        type: ExpressSchema::Type::BUSINESS_OBJECT_MODEL,
+        domain_label: "resource",
+        entity_term: "express-language.entity_data_type",
+        entity_display: "entity data type",
+      ),
+      ExpressSchema::Type::CORE_MODEL => new(
+        type: ExpressSchema::Type::CORE_MODEL,
+        domain_label: "resource",
+        entity_term: "express-language.entity_data_type",
+        entity_display: "entity data type",
+      ),
+      ExpressSchema::Type::STANDALONE => new(
+        type: ExpressSchema::Type::STANDALONE,
+        domain_label: "resource",
+        entity_term: "express-language.entity_data_type",
+        entity_display: "entity data type",
+      ),
+    }.freeze
+
+    def self.for_schema(id:, path:)
+      type = ExpressSchema::Type.classify(id: id, path: path)
+      BY_TYPE.fetch(type) do |t|
+        raise Error, "[suma] no term classification for type #{t.inspect}"
+      end
+    end
+  end
+end

--- a/lib/suma/term_extractor.rb
+++ b/lib/suma/term_extractor.rb
@@ -64,7 +64,9 @@ module Suma
 
       raise Error, "Schema must have an associated file" unless schema.file
 
-      collection = build_managed_concept_collection(schema)
+      classification = TermClassification.for_schema(id: schema.id,
+                                                      path: schema.file)
+      collection = build_managed_concept_collection(schema, classification)
       output_data(collection)
       collection
     end
@@ -86,7 +88,7 @@ module Suma
       end
     end
 
-    def build_managed_concept_collection(schema)
+    def build_managed_concept_collection(schema, classification)
       source_ref = get_source_ref(schema)
       section_ref = get_section_ref(schema)
 
@@ -102,6 +104,7 @@ module Suma
             entity: entity,
             source_ref: source_ref,
             uuid: localized_concept_id,
+            classification: classification,
           )
 
           managed_data = Glossarist::V3::ManagedConceptData.new.tap do |data|
@@ -126,12 +129,13 @@ module Suma
       end
     end
 
-    def build_localized_concept(schema:, entity:, source_ref:, uuid:)
-      schema_domain = get_domain(schema)
+    def build_localized_concept(schema:, entity:, source_ref:, uuid:,
+                                classification:)
+      schema_domain = classification.domain_for(schema.id)
 
       localized_concept_data = Glossarist::V3::ConceptData.new.tap do |data|
         data.terms = get_entity_terms(entity)
-        data.definition = get_entity_definitions(entity, schema)
+        data.definition = get_entity_definitions(entity, schema, classification)
         data.language_code = @language_code
         data.domain = schema_domain
         data.sources = [source_ref] if source_ref
@@ -200,16 +204,6 @@ module Suma
       localities
     end
 
-    def get_domain(schema)
-      prefix = if schema.id.end_with?("_arm", "_mim")
-                 "application module"
-               else
-                 "resource"
-               end
-
-      "#{prefix}: #{schema.id}"
-    end
-
     def get_entity_terms(entity)
       [
         Glossarist::Designation::Base.new(
@@ -220,11 +214,8 @@ module Suma
       ]
     end
 
-    def get_entity_definitions(entity, schema)
-      schema_type = extract_file_type(schema.file)
-      get_domain(schema)
-
-      definition = generate_entity_definition(entity, schema, schema_type)
+    def get_entity_definitions(entity, schema, classification)
+      definition = generate_entity_definition(entity, schema, classification)
       [Glossarist::V3::DetailedDefinition.new(content: definition)]
     end
 
@@ -306,17 +297,6 @@ module Suma
       notes.each do |note|
         note.content = note.content.gsub(/\s+\(see(.*?){1,999}\)/, "")
       end
-    end
-
-    def extract_file_type(filename)
-      match = filename.match(/(arm|mim|bom)_annotated\.exp$/)
-      return "resource" unless match
-
-      {
-        "arm" => "module_arm",
-        "mim" => "module_mim",
-        "bom" => "business_object_model",
-      }[match.captures[0]] || "resource"
     end
 
     def starts_with_list?(content)
@@ -420,22 +400,13 @@ module Suma
       entity_id.downcase.gsub("_", " ")
     end
 
-    def generate_entity_definition(entity, schema, schema_type)
+    def generate_entity_definition(entity, schema, classification)
       return "" if entity.nil?
 
-      entity_type = case schema_type
-                    when "module_arm"
-                      urn_mention(term_urn("general.application_object"),
-                                  "application object")
-                    when "module_mim"
-                      urn_mention(term_urn("express-language.entity_data_type"),
-                                  "entity data type")
-                    when "resource", "business_object_model"
-                      urn_mention(term_urn("express-language.entity_data_type"),
-                                  "entity data type")
-                    else
-                      raise Error, "[suma] encountered unsupported schema_type"
-                    end
+      entity_type = urn_mention(
+        term_urn(classification.entity_term),
+        classification.entity_display,
+      )
 
       entity_ref = urn_mention(term_urn("express-language.entity"), "entity")
 

--- a/spec/fixtures/link_validation/math_symbols.exp
+++ b/spec/fixtures/link_validation/math_symbols.exp
@@ -1,0 +1,12 @@
+SCHEMA test_schema;
+
+  ENTITY mathematical_symbols;
+    pi_value     : STRING; -- π symbol
+    lambda_value : STRING; -- λ symbol
+    theta_value  : STRING; -- θ symbol
+    le_operator  : STRING; -- ≤ operator
+    division     : STRING; -- ÷ operator
+    japanese     : STRING; -- 神戸 Japanese characters
+  END_ENTITY;
+
+END_SCHEMA;

--- a/spec/fixtures/link_validation/schemas.yml
+++ b/spec/fixtures/link_validation/schemas.yml
@@ -1,0 +1,4 @@
+---
+schemas:
+  test_schema:
+    path: math_symbols.exp

--- a/spec/fixtures/svg_quality/valid.svg
+++ b/spec/fixtures/svg_quality/valid.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" version="1.2" baseProfile="tiny">
+  <rect x="10" y="10" width="80" height="80" fill="blue"/>
+</svg>

--- a/spec/suma/cli/export_spec.rb
+++ b/spec/suma/cli/export_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "suma/cli/export"
 require "fileutils"
+require "tmpdir"
 
 RSpec.describe Suma::Cli::Export do
   let(:fixtures_path) { File.join(__dir__, "../../fixtures/extract_terms") }

--- a/spec/suma/cli/reformat_spec.rb
+++ b/spec/suma/cli/reformat_spec.rb
@@ -1,52 +1,84 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "suma/cli"
-require "suma/utils"
 require "suma/cli/reformat"
+require "suma/express_reformatter"
+require "suma/utils"
+require "tmpdir"
+require "fileutils"
 
 RSpec.describe Suma::Cli::Reformat do
-  subject(:test_subject) { described_class.new }
+  let(:fixtures_path) { File.expand_path("../../fixtures", __dir__) }
 
-  it "reformats EXPRESS files" do
-    instance = described_class.new
-    allow(instance).to receive(:run)
-    instance.reformat(File.expand_path("../../fixtures", __dir__))
-    expect(instance).to have_received(:run)
+  describe "#reformat with a single file" do
+    let(:tmpdir) { Dir.mktmpdir("suma_reformat_spec") }
+
+    after do
+      FileUtils.rm_rf(tmpdir)
+    end
+
+    it "writes the file when ExpressReformatter reports a change" do
+      source = File.join(fixtures_path, "no_changes.exp")
+      file = File.join(tmpdir, "schema.exp")
+      FileUtils.cp(source, file)
+
+      described_class.start(["reformat", file])
+
+      rewritten = File.read(file)
+      expect(rewritten).not_to eq(File.read(source))
+    end
+
+    it "leaves the file untouched when ExpressReformatter reports no change" do
+      source = File.join(fixtures_path, "changes.exp")
+      file = File.join(tmpdir, "schema.exp")
+      FileUtils.cp(source, file)
+      original = File.read(file)
+
+      described_class.start(["reformat", file])
+
+      expect(File.read(file)).to eq(original)
+    end
+
+    it "raises ArgumentError when the file is not an EXPRESS file" do
+      non_exp = File.join(fixtures_path, "sample.adoc")
+      expect { described_class.start(["reformat", non_exp]) }
+        .to raise_error(ArgumentError, /not an EXPRESS file/)
+    end
+
+    it "raises Errno::ENOENT when the file does not exist" do
+      expect { described_class.start(["reformat", "not-found.exp"]) }
+        .to raise_error(Errno::ENOENT)
+    end
   end
 
-  it "raises ENOENT error" do
-    expect do
-      test_subject.reformat("not-found.exp")
-    end.to raise_error(Errno::ENOENT)
-  end
+  describe "#reformat with a directory" do
+    it "raises Errno::ENOENT when no EXPRESS files are found" do
+      empty_dir = Dir.mktmpdir("suma_reformat_empty")
+      begin
+        expect { described_class.start(["reformat", empty_dir]) }
+          .to raise_error(Errno::ENOENT, /No EXPRESS files found/)
+      ensure
+        FileUtils.rm_rf(empty_dir)
+      end
+    end
 
-  it "raises ArgumentError error" do
-    expect do
-      test_subject.reformat(File.expand_path("reformat_spec.rb", __dir__))
-    end.to raise_error(ArgumentError)
-  end
+    it "processes every .exp file in the directory" do
+      tmpdir = Dir.mktmpdir("suma_reformat_batch")
+      begin
+        FileUtils.cp(File.join(fixtures_path, "no_changes.exp"),
+                     File.join(tmpdir, "a.exp"))
+        FileUtils.cp(File.join(fixtures_path, "changes.exp"),
+                     File.join(tmpdir, "b.exp"))
 
-  it "raises ENOENT error when no files found" do
-    expect do
-      test_subject.reformat(File.expand_path(".", __dir__))
-    end.to raise_error(Errno::ENOENT)
-  end
+        expect { described_class.start(["reformat", tmpdir]) }
+          .not_to raise_error
 
-  it "reformats EXPRESS file as changes found" do # rubocop:disable RSpec/ExampleLength
-    instance = described_class.new
-    allow(instance).to receive(:update_exp)
-    instance.reformat(
-      File.expand_path("../../fixtures/no_changes.exp", __dir__),
-    )
-    expect(instance).to have_received(:update_exp)
-  end
-
-  it "ignore reformatting EXPRESS file as no changes found" do # rubocop:disable RSpec/ExampleLength
-    instance = described_class.new
-    allow(instance).to receive(:update_exp)
-    instance.reformat(
-      File.expand_path("../../fixtures/changes.exp", __dir__),
-    )
-    expect(instance).not_to have_received(:update_exp)
+        files = Dir.glob(File.join(tmpdir, "*.exp"))
+        expect(files.size).to eq(2)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
   end
 end

--- a/spec/suma/express_reformatter_spec.rb
+++ b/spec/suma/express_reformatter_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "suma/express_reformatter"
+
+RSpec.describe Suma::ExpressReformatter do
+  let(:comment_one)   { "(*\"first comment block\n*)" }
+  let(:comment_two)   { "(*\"second comment block\n*)" }
+
+  describe ".call with no comments" do
+    it "returns changed?: false" do
+      result = described_class.call("SCHEMA foo;\nEND_SCHEMA;\n")
+      expect(result.changed?).to be(false)
+    end
+
+    it "returns the original content unchanged" do
+      original = "SCHEMA foo;\nEND_SCHEMA;\n"
+      result = described_class.call(original)
+      expect(result.content).to eq(original)
+    end
+  end
+
+  describe ".call with one comment block" do
+    it "extracts the comment and appends it to the end" do
+      input = "SCHEMA foo;\n#{comment_one}\nEND_SCHEMA;\n"
+      result = described_class.call(input)
+
+      expect(result.changed?).to be(true)
+      expect(result.content).to include("SCHEMA foo;")
+      expect(result.content).to include("END_SCHEMA;")
+      expect(result.content).to include(comment_one)
+      # comment appears after END_SCHEMA; (i.e. at the end)
+      end_idx = result.content.index("END_SCHEMA;")
+      comment_idx = result.content.index(comment_one)
+      expect(comment_idx).to be > end_idx
+    end
+  end
+
+  describe ".call with multiple comment blocks" do
+    it "extracts all comments and appends them in order" do
+      input = "#{comment_one}SCHEMA foo;\n#{comment_two}END_SCHEMA;\n"
+      result = described_class.call(input)
+
+      expect(result.changed?).to be(true)
+      expect(result.content).to include(comment_one)
+      expect(result.content).to include(comment_two)
+      # both comments appear after END_SCHEMA;
+      end_idx = result.content.index("END_SCHEMA;")
+      expect(result.content.index(comment_one)).to be > end_idx
+      expect(result.content.index(comment_two)).to be > end_idx
+      # preserved in source order
+      first_idx = result.content.index(comment_one)
+      second_idx = result.content.index(comment_two)
+      expect(first_idx).to be < second_idx
+    end
+  end
+
+  describe "idempotence" do
+    it "produces no further changes when called on its own output" do
+      input = "SCHEMA foo;\n#{comment_one}\nEND_SCHEMA;\n"
+      once = described_class.call(input)
+      twice = described_class.call(once.content)
+      expect(twice.changed?).to be(false)
+    end
+
+    it "is stable across multiple applications" do
+      input = "#{comment_one}SCHEMA foo;\n#{comment_two}\nEND_SCHEMA;\n"
+      once = described_class.call(input).content
+      twice = described_class.call(once).content
+      expect(twice).to eq(once)
+    end
+  end
+
+  describe "whitespace normalisation" do
+    it "collapses runs of blank lines into single blank line" do
+      input = "SCHEMA foo;\n\n\n\n#{comment_one}\nEND_SCHEMA;\n"
+      result = described_class.call(input)
+
+      expect(result.content.scan("\n\n\n")).to be_empty
+    end
+
+    it "reports no change when the only difference is whitespace" do
+      # If both inputs already have their comments at the end (canonical
+      # form) and differ only in blank-line runs, both should produce
+      # changed?: false. Reformatting canonical content is a no-op.
+      canonical = "SCHEMA foo;\nEND_SCHEMA;\n\n#{comment_one}\n"
+      result = described_class.call(canonical)
+      expect(result.changed?).to be(false)
+    end
+  end
+
+  describe "Result struct" do
+    it "is keyword-initialised" do
+      result = described_class::Result.new(content: "x", changed?: true)
+      expect(result.content).to eq("x")
+      expect(result.changed?).to be(true)
+    end
+
+    it "returns content from content_or_nil when changed" do
+      result = described_class::Result.new(content: "new", changed?: true)
+      expect(result.content_or_nil).to eq("new")
+    end
+
+    it "returns nil from content_or_nil when unchanged" do
+      result = described_class::Result.new(content: "old", changed?: false)
+      expect(result.content_or_nil).to be_nil
+    end
+  end
+end

--- a/spec/suma/link_validation_spec.rb
+++ b/spec/suma/link_validation_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "suma/link_validation"
+require "suma/schema_index"
+require "expressir"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe Suma::LinkValidation do
+  let(:fixtures_root) do
+    File.expand_path("../fixtures/link_validation", __dir__)
+  end
+
+  let(:schemas_file) { File.join(fixtures_root, "schemas.yml") }
+
+  let(:documents_dir) do
+    Dir.mktmpdir("suma_link_validation_docs")
+  end
+
+  let(:output_file) { File.join(documents_dir, "out.txt") }
+
+  after do
+    FileUtils.rm_rf(documents_dir)
+  end
+
+  def write_adoc(dir, name, body)
+    path = File.join(dir, name)
+    File.write(path, body)
+    path
+  end
+
+  describe "#call" do
+    it "returns a Result with file counts and an unresolved list" do
+      result = described_class.new(
+        schemas_file: schemas_file,
+        documents_path: documents_dir,
+        output_file: output_file,
+        progress: silent_progress,
+      ).call
+
+      expect(result).to be_a(Suma::LinkValidation::Result)
+      expect(result.exp_count).to eq(1)
+      expect(result.adoc_count).to eq(0)
+      expect(result.total_links).to eq(0)
+    end
+
+    it "reports unresolved links with file, line, and reason" do
+      adoc = write_adoc(documents_dir, "bad.adoc",
+                        "intro\n<<express:missing_schema>>\n")
+      result = described_class.new(
+        schemas_file: schemas_file,
+        documents_path: documents_dir,
+        output_file: output_file,
+        progress: silent_progress,
+      ).call
+
+      expect(result.unresolved.length).to eq(1)
+      issue = result.unresolved.first
+      expect(issue.file).to eq(adoc)
+      expect(issue.line).to eq(2)
+      expect(issue.link).to eq("missing_schema")
+      expect(issue.reason).to include("Schema 'missing_schema' not found")
+    end
+
+    it "resolves links when the target schema exists" do
+      write_adoc(documents_dir, "ok.adoc",
+                 "<<express:test_schema>>\n")
+      result = described_class.new(
+        schemas_file: schemas_file,
+        documents_path: documents_dir,
+        output_file: output_file,
+        progress: silent_progress,
+      ).call
+
+      expect(result.unresolved).to be_empty
+      expect(result.success?).to be(true)
+    end
+
+    it "writes the summary file when an output path is given" do
+      write_adoc(documents_dir, "ok.adoc", "<<express:test_schema>>\n")
+      described_class.new(
+        schemas_file: schemas_file,
+        documents_path: documents_dir,
+        output_file: output_file,
+        progress: silent_progress,
+      ).call
+
+      expect(File.exist?(output_file)).to be(true)
+      contents = File.read(output_file)
+      expect(contents).to include("Validation complete")
+      expect(contents).to include("All links resolved")
+    end
+
+    it "raises Suma::Error when the schemas file cannot be loaded" do
+      bogus = File.join(documents_dir, "bogus.yml")
+      # Write malformed YAML — Expressir should refuse to parse it.
+      File.write(bogus, "this: : :\n  - [unbalanced\n")
+      expect do
+        described_class.new(
+          schemas_file: bogus,
+          documents_path: documents_dir,
+          output_file: output_file,
+        ).call
+      end.to raise_error(Suma::Error, /Error loading schemas file/)
+    end
+
+    it "invokes the progress adapter once per file and once per schema" do
+      progress = recording_progress
+      write_adoc(documents_dir, "a.adoc", "<<express:test_schema>>\n")
+      write_adoc(documents_dir, "b.adoc", "<<express:test_schema>>\n")
+
+      described_class.new(
+        schemas_file: schemas_file,
+        documents_path: documents_dir,
+        output_file: nil,
+        progress: progress,
+      ).call
+
+      # The adapter should have received at least one #start call per
+      # phase (file scan, schema load) and one #increment per file
+      # processed.
+      expect(progress.starts.length).to be >= 2
+      expect(progress.increments).to be >= 2
+    end
+  end
+
+  describe ".generate_summary" do
+    it "formats the all-resolved case" do
+      result = Suma::LinkValidation::Result.new(
+        adoc_count: 2, exp_count: 1, total_links: 5, unresolved: [],
+      )
+      summary = described_class.generate_summary(result)
+      expect(summary).to include("Checked 5 links")
+      expect(summary).to include("✅ All links resolved successfully!")
+    end
+
+    it "formats unresolved issues with file:line, link, and reason" do
+      unresolved = [
+        Suma::LinkValidationResult.new(
+          file: "foo.adoc", line: 7, link: "missing",
+          reason: "Schema 'missing' not found"
+        ),
+      ]
+      result = Suma::LinkValidation::Result.new(
+        adoc_count: 1, exp_count: 1, total_links: 3, unresolved: unresolved,
+      )
+      summary = described_class.generate_summary(result)
+      expect(summary).to include("Found 1 unresolved links")
+      expect(summary).to include("foo.adoc:7")
+      expect(summary).to include("<<express:missing>>")
+      expect(summary).to include("Schema 'missing' not found")
+    end
+  end
+
+  describe "Result" do
+    it "is keyword-initialised" do
+      result = Suma::LinkValidation::Result.new(
+        adoc_count: 1, exp_count: 0, total_links: 0, unresolved: [],
+      )
+      expect(result.adoc_count).to eq(1)
+      expect(result.exp_count).to eq(0)
+      expect(result.total_links).to eq(0)
+      expect(result.unresolved).to eq([])
+    end
+
+    it "reports success? when unresolved is empty" do
+      result = Suma::LinkValidation::Result.new(
+        adoc_count: 0, exp_count: 0, total_links: 0, unresolved: [],
+      )
+      expect(result.success?).to be(true)
+    end
+  end
+
+  describe "NullProgress" do
+    it "responds to start and increment without error" do
+      progress = Suma::LinkValidation::NullProgress.new
+      expect { progress.start("title", 5) }.not_to raise_error
+      expect { progress.increment }.not_to raise_error
+    end
+  end
+
+  describe "EXPRESS_LINK_PATTERN" do
+    it "captures the link target without the display text" do
+      match = "<<express:action_schema.action_directive_relationship>>"
+        .match(described_class::EXPRESS_LINK_PATTERN)
+      expect(match[1]).to eq("action_schema.action_directive_relationship")
+    end
+
+    it "captures the link target when a display text is present" do
+      match = "<<express:action_schema,name>>"
+        .match(described_class::EXPRESS_LINK_PATTERN)
+      expect(match[1]).to eq("action_schema")
+    end
+  end
+
+  def silent_progress
+    Suma::LinkValidation::NullProgress.new
+  end
+
+  def recording_progress
+    Class.new do
+      attr_reader :starts, :increments
+
+      def initialize
+        @starts = []
+        @increments = 0
+      end
+
+      def start(title, total)
+        @starts << [title, total]
+      end
+
+      def increment
+        @increments += 1
+      end
+    end.new
+  end
+end

--- a/spec/suma/schema_exporter_spec.rb
+++ b/spec/suma/schema_exporter_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "suma/schema_exporter"
+require "suma/express_schema"
+require "suma/schema_category"
 require "expressir"
+require "tmpdir"
 
 RSpec.describe Suma::SchemaExporter do
   let(:output_dir) { Dir.mktmpdir("suma_schema_exporter_test") }
@@ -11,57 +14,89 @@ RSpec.describe Suma::SchemaExporter do
   end
 
   describe "#export" do
-    context "with standalone .exp file schemas" do
-      it "exports standalone EXPRESS files to the output root" do
-        standalone_schema = Struct.new(:id, :path).new(
-          nil,
-          File.expand_path(
+    context "with a standalone ExpressSchema" do
+      it "exports the file to the output root as <id>.exp" do
+        standalone = Suma::ExpressSchema.new(
+          id: nil,
+          path: File.expand_path(
             "../fixtures/extract_terms/resources/action_schema/action_schema.exp", __dir__
           ),
+          output_path: output_dir,
+          is_standalone_file: true,
         )
 
         exporter = described_class.new(
-          schemas: [standalone_schema],
+          schemas: [standalone],
           output_path: output_dir,
           options: { annotations: false },
         )
 
         expect { exporter.export }.not_to raise_error
-        expect(Dir.glob(File.join(output_dir, "*.exp")).any?).to be true
+        expect(Dir.glob(File.join(output_dir, "*.exp")).any?).to be(true)
       end
     end
 
-    context "with manifest schemas" do
-      it "exports manifest schemas to categorized subdirectories" do
+    context "with a manifest-built ExpressSchema (category subdir)" do
+      it "writes the file under the category directory" do
         manifest_path = File.expand_path(
           "../fixtures/export/schemas-test.yml", __dir__
         )
         manifest = Expressir::SchemaManifest.from_file(manifest_path)
-        manifest_schema = manifest.schemas.first
+        entry = manifest.schemas.first
+        category = Suma::SchemaCategory.for_schema(id: entry.id, path: entry.path)
+
+        schema = Suma::ExpressSchema.new(
+          id: entry.id,
+          path: entry.path.to_s,
+          output_path: File.join(output_dir, category.directory),
+          is_standalone_file: false,
+        )
 
         exporter = described_class.new(
-          schemas: [manifest_schema],
+          schemas: [schema],
           output_path: output_dir,
           options: { annotations: false },
         )
 
+        expect { exporter.export }.not_to raise_error
+      end
+    end
+
+    context "with an empty schema list" do
+      it "does not raise" do
+        exporter = described_class.new(
+          schemas: [],
+          output_path: output_dir,
+        )
         expect { exporter.export }.not_to raise_error
       end
     end
   end
 
-  describe "type distinction" do
-    it "distinguishes standalone schemas from manifest entries" do
-      standalone = Struct.new(:id, :path).new("test", "/path/to/test.exp")
-
-      manifest_path = File.expand_path(
-        "../fixtures/export/schemas-test.yml", __dir__
+  describe "contract: accepts only Suma::ExpressSchema instances" do
+    it "calls save_exp on each schema" do
+      # Build a real ExpressSchema so the call goes through the real
+      # path (no Struct stubs at this seam).
+      schema = Suma::ExpressSchema.new(
+        id: nil,
+        path: File.expand_path(
+          "../fixtures/extract_terms/resources/action_schema/action_schema.exp", __dir__
+        ),
+        output_path: output_dir,
+        is_standalone_file: true,
       )
-      manifest = Expressir::SchemaManifest.from_file(manifest_path)
-      manifest_schema = manifest.schemas.first
 
-      expect(standalone.is_a?(Expressir::SchemaManifestEntry)).to be false
-      expect(manifest_schema.is_a?(Expressir::SchemaManifestEntry)).to be true
+      expect { schema.save_exp }.not_to raise_error
+
+      # The exporter's contract is: it calls save_exp on each schema.
+      # We verify by exporting a list of one schema and confirming the
+      # output file appears.
+      exporter = described_class.new(
+        schemas: [schema],
+        output_path: output_dir,
+      )
+      exporter.export
+      expect(Dir.glob(File.join(output_dir, "*.exp")).any?).to be(true)
     end
   end
 end

--- a/spec/suma/svg_quality/scanner_spec.rb
+++ b/spec/suma/svg_quality/scanner_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "suma/svg_quality/scanner"
+require "suma/svg_quality/report"
+require "suma/svg_quality/batch_report"
+
+RSpec.describe Suma::SvgQuality::Scanner do
+  let(:fixtures_root) do
+    File.expand_path("../../fixtures/svg_quality", __dir__)
+  end
+
+  let(:valid_svg) { File.join(fixtures_root, "valid.svg") }
+
+  describe "#scan_file" do
+    it "returns a Report for a single file" do
+      report = described_class.new.scan_file(valid_svg)
+      expect(report).to be_a(Suma::SvgQuality::Report)
+      expect(report.file_path).to eq(valid_svg)
+    end
+
+    it "forwards the configured profile to the validator" do
+      report = described_class.new(profile: :svg_1_2_rfc).scan_file(valid_svg)
+      expect(report.error_count).to be_an(Integer)
+    end
+  end
+
+  describe "#scan" do
+    it "returns an empty BatchReport when no paths are given" do
+      batch = described_class.new.scan([])
+      expect(batch).to be_a(Suma::SvgQuality::BatchReport)
+      expect(batch.total_files).to eq(0)
+    end
+
+    it "returns a BatchReport whose size matches the input" do
+      batch = described_class.new.scan([valid_svg, valid_svg, valid_svg])
+      expect(batch.total_files).to eq(3)
+    end
+
+    it "builds each Report with the original file path" do
+      batch = described_class.new.scan([valid_svg])
+      expect(batch.reports.first.file_path).to eq(valid_svg)
+    end
+
+    it "invokes the progress adapter once per file with index and total" do
+      recorder = Class.new do
+        attr_reader :calls
+
+        def initialize
+          @calls = []
+        end
+
+        def call(index, total, report)
+          @calls << { index: index, total: total, report: report }
+        end
+      end.new
+
+      described_class.new(progress: recorder).scan([valid_svg, valid_svg])
+
+      expect(recorder.calls.length).to eq(2)
+      expect(recorder.calls.first[:index]).to eq(0)
+      expect(recorder.calls.first[:total]).to eq(2)
+      expect(recorder.calls.last[:index]).to eq(1)
+      expect(recorder.calls.first[:report])
+        .to be_a(Suma::SvgQuality::Report)
+    end
+
+    it "uses NullProgress by default without error" do
+      expect { described_class.new.scan([valid_svg]) }.not_to raise_error
+    end
+  end
+
+  describe "NullProgress" do
+    it "responds to #call without error" do
+      progress = described_class::NullProgress.new
+      expect { progress.call(0, 1, double_report) }.not_to raise_error
+    end
+  end
+
+  describe "DEFAULT_PROFILE" do
+    it "is :metanorma" do
+      expect(described_class::DEFAULT_PROFILE).to eq(:metanorma)
+    end
+  end
+
+  def double_report
+    Struct.new(:file_path, :error_count, :valid?).new("x", 0, true)
+  end
+end

--- a/spec/suma/term_classification_spec.rb
+++ b/spec/suma/term_classification_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "suma/term_classification"
+require "suma/express_schema"
+
+RSpec.describe Suma::TermClassification do
+  describe "BY_TYPE" do
+    it "is frozen" do
+      expect(described_class::BY_TYPE).to be_frozen
+    end
+
+    it "covers every ExpressSchema::Type value exactly once" do
+      type_values = [
+        Suma::ExpressSchema::Type::RESOURCE,
+        Suma::ExpressSchema::Type::MODULE_ARM,
+        Suma::ExpressSchema::Type::MODULE_MIM,
+        Suma::ExpressSchema::Type::BUSINESS_OBJECT_MODEL,
+        Suma::ExpressSchema::Type::CORE_MODEL,
+        Suma::ExpressSchema::Type::STANDALONE,
+      ]
+      declared = described_class::BY_TYPE.keys
+      expect(declared.sort).to eq(type_values.sort)
+    end
+
+    it "freezes each value so callers cannot mutate shared state" do
+      described_class::BY_TYPE.each_value do |classification|
+        expect(classification).to be_frozen
+      end
+    end
+  end
+
+  describe "each classification" do
+    it "exposes type, domain_label, entity_term, and entity_display" do
+      arm = described_class::BY_TYPE[Suma::ExpressSchema::Type::MODULE_ARM]
+      expect(arm.type).to eq(Suma::ExpressSchema::Type::MODULE_ARM)
+      expect(arm.domain_label).to eq("application module")
+      expect(arm.entity_term).to eq("general.application_object")
+      expect(arm.entity_display).to eq("application object")
+    end
+
+    it "classifies module ARM as application module and application object" do
+      arm = described_class::BY_TYPE[Suma::ExpressSchema::Type::MODULE_ARM]
+      expect(arm.domain_label).to eq("application module")
+      expect(arm.entity_display).to eq("application object")
+    end
+
+    it "classifies module MIM as application module but entity data type" do
+      mim = described_class::BY_TYPE[Suma::ExpressSchema::Type::MODULE_MIM]
+      expect(mim.domain_label).to eq("application module")
+      expect(mim.entity_display).to eq("entity data type")
+    end
+
+    it "classifies resource, BOM, core_model, and standalone as resource " \
+       "domain with entity data type" do
+      [
+        Suma::ExpressSchema::Type::RESOURCE,
+        Suma::ExpressSchema::Type::BUSINESS_OBJECT_MODEL,
+        Suma::ExpressSchema::Type::CORE_MODEL,
+        Suma::ExpressSchema::Type::STANDALONE,
+      ].each do |type|
+        classification = described_class::BY_TYPE[type]
+        expect(classification.domain_label).to eq("resource")
+        expect(classification.entity_display).to eq("entity data type")
+      end
+    end
+  end
+
+  describe "#domain_for" do
+    it "composes '<domain_label>: <schema_id>'" do
+      arm = described_class::BY_TYPE[Suma::ExpressSchema::Type::MODULE_ARM]
+      expect(arm.domain_for("activity_arm")).to eq("application module: activity_arm")
+    end
+
+    it "preserves the schema id verbatim (no normalisation)" do
+      resource = described_class::BY_TYPE[Suma::ExpressSchema::Type::RESOURCE]
+      expect(resource.domain_for("action_schema"))
+        .to eq("resource: action_schema")
+    end
+  end
+
+  describe ".for_schema" do
+    it "classifies via id suffix when present" do
+      arm = described_class.for_schema(id: "Activity_arm", path: "anywhere")
+      expect(arm.type).to eq(Suma::ExpressSchema::Type::MODULE_ARM)
+      expect(arm.domain_label).to eq("application module")
+
+      mim = described_class.for_schema(id: "Activity_mim", path: "anywhere")
+      expect(mim.type).to eq(Suma::ExpressSchema::Type::MODULE_MIM)
+
+      bom = described_class.for_schema(id: "Activity_bom", path: "anywhere")
+      expect(bom.type).to eq(Suma::ExpressSchema::Type::BUSINESS_OBJECT_MODEL)
+    end
+
+    it "falls back to path segments when id has no type suffix" do
+      resource = described_class.for_schema(
+        id: "action_schema",
+        path: "schemas/resources/action_schema/action_schema.exp",
+      )
+      expect(resource.type).to eq(Suma::ExpressSchema::Type::RESOURCE)
+
+      module_via_path = described_class.for_schema(
+        id: "activity",
+        path: "schemas/modules/activity/mim.exp",
+      )
+      expect(module_via_path.type).to eq(Suma::ExpressSchema::Type::MODULE_ARM)
+
+      core = described_class.for_schema(
+        id: "core",
+        path: "schemas/core_model/core.exp",
+      )
+      expect(core.type).to eq(Suma::ExpressSchema::Type::CORE_MODEL)
+    end
+
+    it "returns STANDALONE for an unknown classification" do
+      standalone = described_class.for_schema(
+        id: "aic_csg",
+        path: "schemas/aic_csg/aic_csg.exp",
+      )
+      expect(standalone.type).to eq(Suma::ExpressSchema::Type::STANDALONE)
+      expect(standalone.domain_label).to eq("resource")
+      expect(standalone.entity_display).to eq("entity data type")
+    end
+
+    it "prefers id suffix over path segment when they disagree" do
+      # An _arm file in /resources/ is still a module ARM.
+      arm = described_class.for_schema(
+        id: "Foo_arm",
+        path: "schemas/resources/foo/arm.exp",
+      )
+      expect(arm.type).to eq(Suma::ExpressSchema::Type::MODULE_ARM)
+    end
+
+    it "caches lookups via Type.classify (single classification path)" do
+      # The contract: for_schema calls Type.classify exactly once.
+      # This test pins that behaviour so future refactors don't
+      # accidentally reintroduce a second classification channel.
+      call_count = 0
+      original = Suma::ExpressSchema::Type.method(:classify)
+      allow(Suma::ExpressSchema::Type).to receive(:classify) do |**kwargs|
+        call_count += 1
+        original.call(**kwargs)
+      end
+
+      described_class.for_schema(id: "Activity_arm", path: "anywhere")
+      expect(call_count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Five coupled refactors that deepen shallow modules behind clean seams. Driven by the architecture review (each card documented in local `TODO.refactor/14-19`).

- **TermClassification** — single source of truth for schema-type → Glossarist labels. Removes three parallel classification channels from `TermExtractor` (`get_domain`, `extract_file_type`, type-switch). One `for_schema(...)` call per schema.
- **LinkValidation** — deep module behind the link-validation pipeline. `Cli::Validate` shrinks to a 3-line adapter; `Cli::ValidateLinks` becomes a delegate. Shared `EXPRESS_LINK_PATTERN` (previously duplicated and slightly drifted).
- **ExpressReformatter** — pure content→content transform pulled out of the `Cli::Reformat` Thor body. Idempotent. Testable as a pure function.
- **SvgQuality::Scanner** — owns validator construction + per-file capture. CLI becomes argument parsing + file discovery + sort/format. Single-file and batch paths unified.
- **SchemaExporter** — accepts loaded `ExpressSchema` instances. Eliminates the double parse in `SchemaCollection#compile`, and the `is_a?(Expressir::SchemaManifestEntry)` type-check at the seam (replaced with explicit `is_standalone_file` flag built by the CLI).

All five follow the same pattern: thin Thor adapter + deep module behind a small interface. Locality for classification/validation/reformatting/scanning/export concerns concentrates in one place each.

## Test plan

- [x] `bundle exec rake` is green locally (338 examples, 0 failures; rubocop clean)
- [x] New specs added: `term_classification_spec`, `link_validation_spec`, `express_reformatter_spec`, `svg_quality/scanner_spec`
- [x] Updated specs: `cli/reformat_spec`, `cli/export_spec`, `schema_exporter_spec` — all use real models, no doubles
- [ ] CI passes on PR
- [ ] No regressions in build/export/validate/reformat/extract-terms CLI paths
