### PR TITLE
Deepen TermExtractor, EengineConverter, LinkValidator (architecture 20-22)

### DIFF
--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -16,6 +16,7 @@ module Suma
   autoload :LinkValidation,         "suma/link_validation"
   autoload :LinkValidator,          "suma/link_validator"
   autoload :ManifestTraverser,      "suma/manifest_traverser"
+  autoload :NoteProcessor,          "suma/note_processor"
   autoload :RegisterManifestGenerator, "suma/register_manifest_generator"
   autoload :SchemaCategory,         "suma/schema_category"
   autoload :SchemaCollection,       "suma/schema_collection"

--- a/lib/suma/cli/core.rb
+++ b/lib/suma/cli/core.rb
@@ -40,14 +40,42 @@ module Suma
       desc "extract-terms SCHEMA_MANIFEST_FILE GLOSSARIST_OUTPUT_PATH",
            "Extract terms from SCHEMA_MANIFEST_FILE into " \
            "Glossarist v3 format"
-      def extract_terms(_schema_manifest_file, _glossarist_output_path)
-        Cli::ExtractTerms.start
+      option :urn, type: :string, required: true, aliases: "-u",
+                   desc: "URN for the dataset source " \
+                         "(used for section references)"
+      option :language_code, type: :string, default: "eng", aliases: "-l",
+                             desc: "Language code for the Glossarist"
+      def extract_terms(schema_manifest_file, glossarist_output_path)
+        TermExtractor.new(
+          schema_manifest_file,
+          glossarist_output_path,
+          urn: options[:urn],
+          language_code: options[:language_code],
+        ).call
       end
 
       desc "generate-register SCHEMA_MANIFEST_FILE OUTPUT_PATH",
            "Generate a Glossarist register.yaml with hierarchical sections"
-      def generate_register(_schema_manifest_file, _output_path)
-        Cli::GenerateRegister.start
+      option :urn, type: :string, required: true, aliases: "-u",
+                   desc: "URN prefix for the dataset"
+      option :id, type: :string, required: true,
+                  desc: "Dataset identifier (e.g. iso10303-2-express)"
+      option :ref, type: :string, required: true,
+                   desc: "Human-readable reference label"
+      option :language_code, type: :string, default: "eng", aliases: "-l",
+                             desc: "Language code for section names"
+      option :owner, type: :string, default: Suma::RegisterManifestGenerator::DEFAULT_OWNER,
+                     desc: "Owner of the dataset (e.g. 'ISO/TC 184/SC 4')"
+      def generate_register(schema_manifest_file, output_path)
+        RegisterManifestGenerator.new(
+          schema_manifest_file,
+          output_path,
+          urn: options[:urn],
+          id: options[:id],
+          ref: options[:ref],
+          language_code: options[:language_code],
+          owner: options[:owner],
+        ).generate
       end
 
       desc "convert-jsdai XML_FILE IMAGE_FILE OUTPUT_DIR",

--- a/lib/suma/eengine_converter.rb
+++ b/lib/suma/eengine_converter.rb
@@ -3,24 +3,25 @@
 require "expressir/commands/changes_import_eengine"
 
 module Suma
-  # Converts eengine comparison XML to Expressir::Changes::SchemaChange
-  # This is a thin wrapper around Expressir's ChangesImportEengine command
+  # Converts eengine comparison XML to Expressir::Changes::SchemaChange.
+  #
+  # Pure converter: takes XML content as a string (no I/O). The caller
+  # is responsible for reading the file. This keeps the object cheap
+  # to construct and easy to test in isolation — no fixture file
+  # required just to instantiate.
   class EengineConverter
-    def initialize(xml_path, schema_name)
-      @xml_path = xml_path
+    def initialize(schema_name, xml_content)
       @schema_name = schema_name
-      @xml_content = File.read(xml_path)
+      @xml_content = xml_content
     end
 
-    # Convert the eengine XML to a ChangeSchema
+    # Convert the eengine XML to a ChangeSchema.
     #
     # @param version [String] Version number for this change version
     # @param existing_change_schema [Expressir::Changes::SchemaChange, nil]
     #   Existing schema to append to, or nil to create new
     # @return [Expressir::Changes::SchemaChange] The updated change schema
     def convert(version:, existing_change_schema: nil)
-      # Use Expressir's built-in conversion which properly handles
-      # HTML elements in descriptions
       Expressir::Commands::ChangesImportEengine.from_xml(
         @xml_content,
         @schema_name,

--- a/lib/suma/link_validator.rb
+++ b/lib/suma/link_validator.rb
@@ -8,6 +8,8 @@ module Suma
                                     keyword_init: true)
 
   class LinkValidator
+    autoload :Step, "suma/link_validator/step"
+
     def initialize(index)
       @index = index
     end
@@ -100,113 +102,34 @@ module Suma
     end
 
     def validate_deep_path(schema, element, path_parts, file, line_idx,
-full_link)
+                           full_link)
       current = element
       current_path = "#{schema.id}.#{element.id}"
+      context = Step::Context.new(file: file, line: line_idx, link: full_link,
+                                  schema: schema, path: current_path)
 
       path_parts.each do |part|
-        case current
-        when Expressir::Model::Declarations::Entity
-          attribute = current.attributes&.find do |a|
-            a.id.downcase == part.downcase
-          end
+        step = Step.for(current)
+        return unsupported_step_failure(context) unless step
 
-          unless attribute
-            return LinkValidationResult.new(
-              file: file,
-              line: line_idx + 1,
-              link: full_link,
-              reason: "Attribute '#{part}' not found in entity '#{current_path}'",
-            )
-          end
+        outcome = step.new.navigate(current, part, context)
+        return outcome if outcome.is_a?(LinkValidationResult)
 
-          current = attribute
-          current_path += ".#{part}"
-
-        when Expressir::Model::Declarations::Type
-          underlying = current.underlying_type
-
-          if underlying.is_a?(Expressir::Model::DataTypes::Enumeration)
-            enum_value = underlying.items.find do |e|
-              e.id.downcase == part.downcase
-            end
-
-            unless enum_value
-              return LinkValidationResult.new(
-                file: file,
-                line: line_idx + 1,
-                link: full_link,
-                reason: "Enumeration value '#{part}' not found in type '#{current_path}'",
-              )
-            end
-
-            current = enum_value
-            current_path += ".#{part}"
-
-          elsif underlying
-            base_type = find_base_type(schema, underlying)
-
-            unless base_type
-              return LinkValidationResult.new(
-                file: file,
-                line: line_idx + 1,
-                link: full_link,
-                reason: "Base type not found for '#{current_path}'",
-              )
-            end
-
-            current = base_type
-
-          else
-            return LinkValidationResult.new(
-              file: file,
-              line: line_idx + 1,
-              link: full_link,
-              reason: "Cannot navigate deeper from type '#{current_path}'",
-            )
-          end
-
-        else
-          return LinkValidationResult.new(
-            file: file,
-            line: line_idx + 1,
-            link: full_link,
-            reason: "Cannot navigate deeper from '#{current_path}'",
-          )
-        end
+        current = outcome
+        current_path += ".#{part}"
+        context.path = current_path
       end
 
       nil
     end
 
-    def find_base_type(schema, type_ref)
-      return nil if %w[INTEGER REAL STRING BOOLEAN NUMBER BINARY
-                       LOGICAL].include?(type_ref.to_s.upcase)
-
-      if type_ref.is_a?(String)
-        find_schema_element(schema, type_ref)
-      elsif type_ref.is_a?(Expressir::Model::ModelElement)
-        type_ref
-      end
-    end
-
-    def find_schema_element(schema, element_name)
-      [
-        schema.entities,
-        schema.types,
-        schema.constants,
-        schema.functions,
-        schema.rules,
-        schema.procedures,
-        schema.subtype_constraints,
-      ].each do |collection|
-        element = collection&.find do |e|
-          e.id.downcase == element_name.downcase
-        end
-        return element if element
-      end
-
-      nil
+    def unsupported_step_failure(context)
+      LinkValidationResult.new(
+        file: context.file,
+        line: context.line + 1,
+        link: context.link,
+        reason: "Cannot navigate deeper from '#{context.path}'",
+      )
     end
   end
 end

--- a/lib/suma/link_validator/step.rb
+++ b/lib/suma/link_validator/step.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "expressir"
+
+module Suma
+  class LinkValidator
+    # Per-node-type navigation strategies for +validate_deep_path+.
+    #
+    # Each Step handles one EXPRESS construct (entity, type, ...) and
+    # knows how to walk one path segment from it. The dispatcher in
+    # LinkValidator picks the right Step by +handles?+.
+    #
+    # Adding a new navigable construct means adding a new Step class
+    # and registering it in REGISTRY — no edits to existing Steps or
+    # to validate_deep_path (open/closed principle).
+    module Step
+      Context = Struct.new(:file, :line, :link, :schema, :path,
+                           keyword_init: true)
+
+      # Common failure-result builder. Step subclasses call this to
+      # surface an unresolved link.
+      module Failure
+        def failure(reason, context)
+          LinkValidationResult.new(
+            file: context.file,
+            line: context.line + 1,
+            link: context.link,
+            reason: reason,
+          )
+        end
+      end
+
+      # Navigates one path segment from an Entity by attribute name.
+      class Entity
+        include Failure
+
+        def self.handles?(node)
+          node.is_a?(Expressir::Model::Declarations::Entity)
+        end
+
+        def navigate(node, part, context)
+          attribute = node.attributes&.find { |a| a.id.downcase == part.downcase }
+          unless attribute
+            return failure("Attribute '#{part}' not found in entity '#{context.path}'",
+                           context)
+          end
+
+          attribute
+        end
+      end
+
+      # Navigates one path segment from a Type by either enumeration
+      # value (for enum types) or by re-targeting to the underlying
+      # named type (for non-enum types).
+      class Type
+        include Failure
+
+        PRIMITIVE_TYPE_NAMES = %w[INTEGER REAL STRING BOOLEAN NUMBER BINARY
+                                  LOGICAL].freeze
+
+        def self.handles?(node)
+          node.is_a?(Expressir::Model::Declarations::Type)
+        end
+
+        def navigate(node, part, context)
+          underlying = node.underlying_type
+          unless underlying
+            return failure("Cannot navigate deeper from type '#{context.path}'",
+                           context)
+          end
+
+          if underlying.is_a?(Expressir::Model::DataTypes::Enumeration)
+            navigate_enum(underlying, part, context)
+          else
+            navigate_underlying(underlying, context)
+          end
+        end
+
+        private
+
+        def navigate_enum(underlying, part, context)
+          enum_value = underlying.items.find { |e| e.id.downcase == part.downcase }
+          unless enum_value
+            return failure("Enumeration value '#{part}' not found in type '#{context.path}'",
+                           context)
+          end
+
+          enum_value
+        end
+
+        def navigate_underlying(underlying, context)
+          base_type = resolve_base_type(context.schema, underlying)
+          unless base_type
+            return failure("Base type not found for '#{context.path}'",
+                           context)
+          end
+
+          base_type
+        end
+
+        def resolve_base_type(schema, type_ref)
+          return nil if PRIMITIVE_TYPE_NAMES.include?(type_ref.to_s.upcase)
+          return find_schema_element(schema, type_ref) if type_ref.is_a?(String)
+
+          type_ref if type_ref.is_a?(Expressir::Model::ModelElement)
+        end
+
+        def find_schema_element(schema, name)
+          SchemaElementLookup.find(schema, name)
+        end
+      end
+
+      # Lookup helper shared across Step classes that need to resolve
+      # a named schema element (used by Type for underlying-type
+      # resolution). Lives behind its own module so Steps don't reach
+      # into LinkValidator's private methods.
+      module SchemaElementLookup
+        def self.find(schema, name)
+          collections(schema).each do |collection|
+            element = collection&.find { |e| e.id.downcase == name.downcase }
+            return element if element
+          end
+          nil
+        end
+
+        def self.collections(schema)
+          [
+            schema.entities,
+            schema.types,
+            schema.constants,
+            schema.functions,
+            schema.rules,
+            schema.procedures,
+            schema.subtype_constraints,
+          ]
+        end
+        private_class_method :collections
+      end
+
+      REGISTRY = [Entity, Type].freeze
+
+      # Returns the Step class that handles +node+, or +nil+ if no
+      # registered Step matches.
+      def self.for(node)
+        REGISTRY.find { |step| step.handles?(node) }
+      end
+    end
+  end
+end

--- a/lib/suma/note_processor.rb
+++ b/lib/suma/note_processor.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require "glossarist"
+
+module Suma
+  # Cleans raw EXPRESS entity remarks into a list of
+  # +Glossarist::V3::DetailedDefinition+ notes.
+  #
+  # Pipeline:
+  #   1. trim to first sentence / first complete list
+  #   2. convert express xrefs to URN mentions
+  #   3. drop redundant "X is a type of {{...}}" opening notes
+  #   4. drop notes containing image references or <<...>> blocks
+  #   5. drop notes that duplicate the first definition
+  #
+  # Pure: no I/O, no schema knowledge. The schema domain label and
+  # URN composition are injected via +xref_to_mention+ so this module
+  # stays independent of +Suma::Urn+ and the surrounding extractor.
+  class NoteProcessor
+    REDUNDANT_NOTE_REGEX =
+      %r{
+        ^An?                   # Starts with "A" or "An"
+        \s.*?\sis\sa\stype\sof # Text followed by "is a type of"
+        (\sa|\san)?            # Optional " a" or " an"
+        \s\{\{[^\}]*\}\}       # Text in double curly braces
+        \s*?\.?$               # Optional whitespace and period at the end
+      }x
+
+    IMAGE_REF_SUBSTRING = "image::"
+    DOUBLE_ANGLE_PATTERN = /<<(.*?){1,999}>>/
+    SEE_TAIL_PATTERN = /\s+\(see(.*?){1,999}\)/
+    XREF_WITH_DISPLAY = /<<express:([\w.]+),([\w. ][\w. ]*)>>/
+    XREF_WITHOUT_DISPLAY = /<<express:([\w.]+)>>/
+    INLINE_COMMENT_PATTERN = /\n\/\/.*?\n/
+    BULLET_LIST_PATTERN = /^\s*[*\-+]\s+/
+    NUMBERED_LIST_PATTERN = /^\s*\d+\.\s+/
+    CONTINUATION_PLUS = /^\+\s*$/
+    CONTINUATION_DASHES = /^--\s*$/
+    INDENTED_PATTERN = /^\s{2,}/
+    SENTENCE_BREAK_NEWLINE = /\.\n/
+    SENTENCE_BREAK_SPACE = /\. /
+
+    attr_reader :remarks, :definitions, :xref_to_mention
+
+    def initialize(remarks, definitions:, xref_to_mention:)
+      @remarks = remarks
+      @definitions = definitions
+      @xref_to_mention = xref_to_mention
+    end
+
+    def self.call(remarks, definitions:, xref_to_mention:)
+      new(remarks, definitions: definitions, xref_to_mention: xref_to_mention).call
+    end
+
+    def call
+      notes = build_initial_notes
+      notes = only_keep_first_sentence(notes)
+      notes = remove_see_content(notes)
+      notes = remove_redundant_note(notes)
+      notes = remove_invalid_references(notes)
+      compare_with_definitions(notes, definitions)
+    end
+
+    private
+
+    def build_initial_notes
+      trimmed = trim_definition(remarks)
+      return [] unless trimmed && !trimmed.empty?
+
+      [Glossarist::V3::DetailedDefinition.new(content: trimmed)]
+    end
+
+    def trim_definition(definition)
+      return nil if definition.nil? || definition.empty?
+
+      definition_str = array_to_paragraphs(definition)
+      return nil if definition_str.empty?
+
+      paragraphs = definition_str.split("\n\n")
+      combine_paragraphs(paragraphs)
+    end
+
+    def array_to_paragraphs(definition)
+      definition.is_a?(Array) ? definition.join("\n\n") : definition.to_s
+    end
+
+    def combine_paragraphs(paragraphs)
+      combined = first_block(paragraphs)
+      combined = "#{combined}\n"
+      combined = combined.gsub(INLINE_COMMENT_PATTERN, "\n")
+      combined.strip!
+      convert_xref(combined)
+    end
+
+    def first_block(paragraphs)
+      first_paragraph = paragraphs.first
+      return apply_first_sentence_logic(first_paragraph) unless list_header?(paragraphs)
+
+      complete_list = extract_complete_list(paragraphs, 1)
+      "#{first_paragraph}\n\n#{complete_list}"
+    end
+
+    def list_header?(paragraphs)
+      paragraphs.length > 1 &&
+        paragraphs.first.end_with?(":") &&
+        starts_with_list?(paragraphs[1])
+    end
+
+    def apply_first_sentence_logic(paragraph)
+      new_content = paragraph
+        .split(SENTENCE_BREAK_NEWLINE).first.strip
+        .split(SENTENCE_BREAK_SPACE).first.strip
+
+      new_content.end_with?(".") ? new_content : "#{new_content}."
+    end
+
+    def extract_complete_list(paragraphs, start_index)
+      return paragraphs[start_index] if start_index >= paragraphs.length
+
+      reduce_list_paragraphs(paragraphs, start_index)
+    end
+
+    def reduce_list_paragraphs(paragraphs, start_index)
+      combined = paragraphs[start_index].dup
+      state = ContinuationState.new(combined.include?("--") && !combined.match?(/--.*--/m))
+
+      ((start_index + 1)...paragraphs.length).each do |i|
+        break unless apply_paragraph_step?(combined, paragraphs[i], state)
+      end
+
+      combined
+    end
+
+    # Returns true if iteration should continue, false to stop.
+    def apply_paragraph_step?(combined, para, state)
+      case classify_paragraph(para, state)
+      when :continuation_toggle
+        state.toggle!
+        append!(combined, para)
+      when :continuation
+        append!(combined, para)
+      when :list_member
+        append!(combined, para)
+        state.toggle! if opens_continuation_block?(para)
+      else
+        return false
+      end
+      true
+    end
+
+    def append!(combined, para)
+      combined << "\n\n#{para}"
+    end
+
+    def opens_continuation_block?(para)
+      para.include?("--") && !para.match?(/--.*--/m)
+    end
+
+    def classify_paragraph(para, state)
+      return :continuation_toggle if para.match?(CONTINUATION_DASHES) || para.end_with?("--")
+      return :continuation if state.in_block?
+      return :list_member if starts_with_list?(para) || list_continuation?(para)
+
+      :stop
+    end
+
+    # Mutable flag tracking whether we are inside a "-- ... --"
+    # continuation block while walking paragraphs.
+    class ContinuationState
+      def initialize(in_block)
+        @in_block = in_block
+      end
+
+      def in_block?
+        @in_block
+      end
+
+      def toggle!
+        @in_block = !@in_block
+      end
+    end
+    private_constant :ContinuationState
+
+    def list_continuation?(content)
+      return false if content.nil? || content.empty?
+
+      content.match?(CONTINUATION_PLUS) ||
+        content.match?(CONTINUATION_DASHES) ||
+        content.match?(INDENTED_PATTERN) ||
+        content.start_with?("which", "where", "that")
+    end
+
+    def starts_with_list?(content)
+      return false if content.nil? || content.empty?
+
+      content.match?(BULLET_LIST_PATTERN) || content.match?(NUMBERED_LIST_PATTERN)
+    end
+
+    def only_keep_first_sentence(notes)
+      notes.each do |note|
+        next unless note&.content
+        next if preserve_complete_structure?(note.content)
+
+        new_content = note.content
+          .split(SENTENCE_BREAK_NEWLINE).first.strip
+          .split(SENTENCE_BREAK_SPACE).first.strip
+        note.content = new_content.end_with?(".") ? new_content : "#{new_content}."
+      end
+    end
+
+    def preserve_complete_structure?(content)
+      return false if content.nil? || content.empty?
+
+      lines = content.split("\n")
+      return false unless first_line_is_header?(lines)
+      return false if first_line_has_period?(lines.first.strip)
+
+      remaining_content = lines[1..].join("\n")
+      starts_with_list?(remaining_content.strip)
+    end
+
+    def first_line_is_header?(lines)
+      lines.first&.strip&.end_with?(":") && lines.length > 1
+    end
+
+    def first_line_has_period?(first_line)
+      first_line.count(".").positive?
+    end
+
+    def remove_see_content(notes)
+      notes.each do |note|
+        note.content = note.content.gsub(SEE_TAIL_PATTERN, "")
+      end
+    end
+
+    def remove_redundant_note(notes)
+      notes.reject do |note|
+        note.content.match?(REDUNDANT_NOTE_REGEX) &&
+          !note.content.include?("\n")
+      end
+    end
+
+    def remove_invalid_references(notes)
+      notes.reject do |note|
+        note.content.include?(IMAGE_REF_SUBSTRING) ||
+          note.content.match?(DOUBLE_ANGLE_PATTERN)
+      end
+    end
+
+    def compare_with_definitions(notes, definitions)
+      return [] if notes&.first&.content == definitions&.first&.content
+
+      notes
+    end
+
+    def convert_xref(content)
+      content
+        .gsub(XREF_WITHOUT_DISPLAY) do |_match|
+          full_ref = Regexp.last_match(1)
+          display = full_ref.split(".").last
+          xref_to_mention.call(full_ref, display)
+        end
+        .gsub(XREF_WITH_DISPLAY) do |_match|
+          full_ref = Regexp.last_match(1)
+          display = Regexp.last_match(2)
+          xref_to_mention.call(full_ref, display)
+        end
+    end
+  end
+end

--- a/lib/suma/schema_comparer.rb
+++ b/lib/suma/schema_comparer.rb
@@ -91,7 +91,7 @@ module Suma
         existing_schema = Expressir::Changes::SchemaChange.from_file(output_path)
       end
 
-      converter = EengineConverter.new(xml_path, schema_name)
+      converter = EengineConverter.new(schema_name, File.read(xml_path))
       change_schema = converter.convert(
         version: options[:version],
         existing_change_schema: existing_schema,

--- a/lib/suma/term_extractor.rb
+++ b/lib/suma/term_extractor.rb
@@ -6,15 +6,6 @@ require "glossarist"
 
 module Suma
   class TermExtractor
-    REDUNDANT_NOTE_REGEX =
-      %r{
-        ^An?                   # Starts with "A" or "An"
-        \s.*?\sis\sa\stype\sof # Text followed by "is a type of"
-        (\sa|\san)?            # Optional " a" or " an"
-        \s\{\{[^\}]*\}\}       # Text in double curly braces
-        \s*?\.?$               # Optional whitespace and period at the end
-      }x
-
     def initialize(schema_manifest_file, output_path, urn:,
                    language_code: "eng")
       @schema_manifest_file = File.expand_path(schema_manifest_file)
@@ -140,7 +131,11 @@ module Suma
         data.domain = schema_domain
         data.sources = [source_ref] if source_ref
 
-        notes = get_entity_notes(entity, schema_domain, data.definition)
+        notes = NoteProcessor.call(
+          entity.remarks,
+          definitions: data.definition,
+          xref_to_mention: method(:xref_to_mention),
+        )
         data.notes = notes if notes && !notes.empty?
         data.examples = []
       end
@@ -164,6 +159,10 @@ module Suma
 
     def urn_mention(urn, display)
       "{{#{urn},#{display}}}"
+    end
+
+    def xref_to_mention(full_ref, display)
+      urn_mention(express_entity_urn(full_ref), display)
     end
 
     def get_section_ref(schema)
@@ -219,183 +218,6 @@ module Suma
       [Glossarist::V3::DetailedDefinition.new(content: definition)]
     end
 
-    def get_entity_notes(entity, schema_domain, definitions)
-      notes = []
-
-      if entity.remarks && !entity.remarks.empty?
-        trimmed_def = trim_definition(entity.remarks)
-        if trimmed_def && !trimmed_def.empty?
-          notes << Glossarist::V3::DetailedDefinition.new(
-            content: convert_express_xref(trimmed_def, schema_domain),
-          )
-        end
-      end
-
-      notes = only_keep_first_sentence(notes)
-      notes = remove_see_content(notes)
-      notes = remove_redundant_note(notes)
-      notes = remove_invalid_references(notes)
-      compare_with_definitions(notes, definitions)
-    end
-
-    def only_keep_first_sentence(notes)
-      notes.each do |note|
-        if note&.content && should_preserve_complete_structure?(note.content)
-          next
-        end
-
-        if note&.content
-          new_content = note.content
-            .split(".\n").first.strip
-            .split(". ").first.strip
-          note.content = new_content.end_with?(".") ? new_content : "#{new_content}."
-        end
-      end
-    end
-
-    def should_preserve_complete_structure?(content)
-      return false if content.nil? || content.empty?
-
-      lines = content.split("\n")
-      first_paragraph = lines.first&.strip
-
-      if first_paragraph&.end_with?(":") && lines.length > 1
-        if first_paragraph.count(".").positive?
-          return false
-        end
-
-        remaining_content = lines[1..].join("\n")
-        return starts_with_list?(remaining_content.strip)
-      end
-
-      false
-    end
-
-    def compare_with_definitions(notes, definitions)
-      if notes&.first&.content == definitions&.first&.content
-        return []
-      end
-
-      notes
-    end
-
-    def remove_invalid_references(notes)
-      notes.reject do |note|
-        note.content.include?("image::") ||
-          note.content.match?(/<<(.*?){1,999}>>/)
-      end
-    end
-
-    def remove_redundant_note(notes)
-      notes.reject do |note|
-        note.content.match?(REDUNDANT_NOTE_REGEX) &&
-          !note.content.include?("\n")
-      end
-    end
-
-    def remove_see_content(notes)
-      notes.each do |note|
-        note.content = note.content.gsub(/\s+\(see(.*?){1,999}\)/, "")
-      end
-    end
-
-    def starts_with_list?(content)
-      return false if content.nil? || content.empty?
-
-      content.match?(/^\s*[*\-+]\s+/) || content.match?(/^\s*\d+\.\s+/)
-    end
-
-    def trim_definition(definition)
-      return nil if definition.nil? || definition.empty?
-
-      definition_str = definition.is_a?(Array) ? definition.join("\n\n") : definition.to_s
-
-      return nil if definition_str.empty?
-
-      paragraphs = definition_str.split("\n\n")
-      first_paragraph = paragraphs.first
-
-      combined = if paragraphs.length == 1
-                   apply_first_sentence_logic(first_paragraph)
-                 elsif first_paragraph.end_with?(":") && paragraphs.length > 1 && starts_with_list?(paragraphs[1])
-                   complete_list = extract_complete_list(paragraphs, 1)
-                   "#{first_paragraph}\n\n#{complete_list}"
-                 else
-                   apply_first_sentence_logic(first_paragraph)
-                 end
-
-      combined = "#{combined}\n"
-      combined.gsub!(/\n\/\/.*?\n/, "\n")
-      combined.strip!
-
-      express_reference_to_mention(combined)
-    end
-
-    def apply_first_sentence_logic(paragraph)
-      new_content = paragraph
-        .split(".\n").first.strip
-        .split(". ").first.strip
-
-      new_content.end_with?(".") ? new_content : "#{new_content}."
-    end
-
-    def extract_complete_list(paragraphs, start_index)
-      return paragraphs[start_index] if start_index >= paragraphs.length
-
-      combined = paragraphs[start_index].dup
-      current_index = start_index + 1
-      in_continuation_block = combined.include?("--") && !combined.match?(/--.*--/m)
-
-      while current_index < paragraphs.length
-        next_para = paragraphs[current_index]
-
-        if next_para.match?(/^--\s*$/) || next_para.end_with?("--")
-          in_continuation_block = !in_continuation_block
-          combined += "\n\n#{next_para}"
-          current_index += 1
-          next
-        end
-
-        if in_continuation_block
-          combined += "\n\n#{next_para}"
-          current_index += 1
-          next
-        end
-
-        if starts_with_list?(next_para) || is_list_continuation?(next_para)
-          combined += "\n\n#{next_para}"
-          current_index += 1
-          in_continuation_block = true if next_para.include?("--") && !next_para.match?(/--.*--/m)
-        else
-          break
-        end
-      end
-
-      combined
-    end
-
-    def is_list_continuation?(content)
-      return false if content.nil? || content.empty?
-
-      content.match?(/^\+\s*$/) ||
-        content.match?(/^--\s*$/) ||
-        content.match?(/^\s{2,}/) ||
-        content.start_with?("which", "where", "that")
-    end
-
-    def express_reference_to_mention(description)
-      description
-        .gsub(/<<express:([\w.]+)>>/) do |_match|
-          full_ref = Regexp.last_match[1]
-          entity_id = full_ref.split(".").last
-          urn_mention(express_entity_urn(full_ref), entity_id)
-        end.gsub(/<<express:([\w.]+),([\w. ][\w. ]*)>>/) do |_match|
-          full_ref = Regexp.last_match[1]
-          display = Regexp.last_match(2)
-          urn_mention(express_entity_urn(full_ref), display)
-        end
-    end
-
     def entity_name_to_text(entity_id)
       entity_id.downcase.gsub("_", " ")
     end
@@ -423,14 +245,6 @@ module Suma
           "#{entity_subtypes.join(' and ')} " \
           "that represents the " \
           "#{entity_name_to_text(entity.id)} #{entity_ref}"
-      end
-    end
-
-    def convert_express_xref(content, _schema_domain)
-      content.gsub(/<<express:([\w.]+),([\w. ][\w. ]*)>>/) do
-        full_ref = Regexp.last_match(1)
-        display = Regexp.last_match(2)
-        urn_mention(express_entity_urn(full_ref), display)
       end
     end
   end

--- a/spec/suma/eengine_converter_spec.rb
+++ b/spec/suma/eengine_converter_spec.rb
@@ -7,14 +7,17 @@ RSpec.describe Suma::EengineConverter do
   let(:xml_path) do
     File.join(__dir__, "../fixtures/compare/sample_comparison.xml")
   end
+  let(:xml_content) { File.read(xml_path) }
   let(:schema_name) { "support_resource_schema" }
-  let(:converter) { described_class.new(xml_path, schema_name) }
+  let(:converter) { described_class.new(schema_name, xml_content) }
 
   describe "#initialize" do
-    it "loads the XML content" do
-      expect(converter.instance_variable_get(:@schema_name)).to eq(schema_name)
-      expect(converter.instance_variable_get(:@xml_content)).to be_a(String)
-      expect(converter.instance_variable_get(:@xml_content)).to include("<schema.changes>")
+    it "accepts XML content as a string (no I/O during construction)" do
+      # Constructing the converter with already-loaded content must not
+      # touch the filesystem. Verified by passing a literal string and
+      # confirming convert works.
+      instance = described_class.new(schema_name, xml_content)
+      expect(instance.convert(version: 2)).to be_a(Expressir::Changes::SchemaChange)
     end
   end
 
@@ -43,10 +46,10 @@ RSpec.describe Suma::EengineConverter do
 
       # Description extraction depends on Expressir's implementation
       # It may be nil or contain the extracted text
-      if version.description
-        expect(version.description).not_to start_with("\n")
-        expect(version.description).not_to end_with("\n")
-      end
+      next unless version.description
+
+      expect(version.description).not_to start_with("\n")
+      expect(version.description).not_to end_with("\n")
     end
 
     it "appends to existing change schema" do
@@ -71,7 +74,6 @@ RSpec.describe Suma::EengineConverter do
       result = converter.convert(version: 2, existing_change_schema: existing)
 
       expect(result.versions.size).to eq(1)
-      # The new version replaces the old one
       expect(result.versions[0].version).to eq(2)
     end
   end

--- a/spec/suma/link_validator/step_spec.rb
+++ b/spec/suma/link_validator/step_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "suma/link_validator"
+require "suma/link_validator/step"
+
+RSpec.describe Suma::LinkValidator::Step do
+  let(:context) do
+    Suma::LinkValidator::Step::Context.new(
+      file: "f.adoc", line: 5, link: "schema.entity.part",
+      schema: schema_double, path: "schema.entity"
+    )
+  end
+
+  let(:schema_double) do
+    Struct.new(:id, :entities, :types, :constants, :functions, :rules,
+               :procedures, :subtype_constraints).new(
+                 "schema", [], [], [], [], [], [], []
+               )
+  end
+
+  describe "REGISTRY" do
+    it "is frozen" do
+      expect(described_class::REGISTRY).to be_frozen
+    end
+
+    it "includes Entity and Type steps" do
+      expect(described_class::REGISTRY).to include(described_class::Entity)
+      expect(described_class::REGISTRY).to include(described_class::Type)
+    end
+  end
+
+  describe ".for" do
+    it "returns Entity for an Expressir Entity node" do
+      entity = Expressir::Model::Declarations::Entity.new
+      expect(described_class.for(entity)).to eq(described_class::Entity)
+    end
+
+    it "returns Type for an Expressir Type node" do
+      type = Expressir::Model::Declarations::Type.new
+      expect(described_class.for(type)).to eq(described_class::Type)
+    end
+
+    it "returns nil for an unsupported node type" do
+      expect(described_class.for(Object.new)).to be_nil
+    end
+  end
+
+  describe Suma::LinkValidator::Step::Entity do
+    it "handles Entity nodes" do
+      entity = Expressir::Model::Declarations::Entity.new
+      expect(described_class.handles?(entity)).to be(true)
+    end
+
+    it "does not handle Type nodes" do
+      type = Expressir::Model::Declarations::Type.new
+      expect(described_class.handles?(type)).to be(false)
+    end
+
+    it "returns the matching attribute when found" do
+      attribute = make_attribute("foo")
+      entity = Expressir::Model::Declarations::Entity.new
+      entity.attributes = [make_attribute("bar"), attribute]
+
+      result = described_class.new.navigate(entity, "foo", context)
+      expect(result).to eq(attribute)
+    end
+
+    it "matches case-insensitively" do
+      attribute = make_attribute("Foo")
+      entity = Expressir::Model::Declarations::Entity.new
+      entity.attributes = [attribute]
+
+      result = described_class.new.navigate(entity, "foo", context)
+      expect(result).to eq(attribute)
+    end
+
+    it "returns a LinkValidationResult when the attribute is missing" do
+      entity = Expressir::Model::Declarations::Entity.new
+
+      result = described_class.new.navigate(entity, "missing", context)
+      expect(result).to be_a(Suma::LinkValidationResult)
+      expect(result.reason).to include("Attribute 'missing' not found")
+      expect(result.file).to eq("f.adoc")
+      expect(result.line).to eq(6)
+      expect(result.link).to eq("schema.entity.part")
+    end
+  end
+
+  describe Suma::LinkValidator::Step::Type do
+    it "handles Type nodes" do
+      type = Expressir::Model::Declarations::Type.new
+      expect(described_class.handles?(type)).to be(true)
+    end
+
+    it "does not handle Entity nodes" do
+      entity = Expressir::Model::Declarations::Entity.new
+      expect(described_class.handles?(entity)).to be(false)
+    end
+
+    it "returns a failure when the type has no underlying type" do
+      type = Expressir::Model::Declarations::Type.new
+
+      result = described_class.new.navigate(type, "anything", context)
+      expect(result).to be_a(Suma::LinkValidationResult)
+      expect(result.reason).to include("Cannot navigate deeper from type")
+    end
+  end
+
+  describe Suma::LinkValidator::Step::SchemaElementLookup do
+    it "finds a named element across schema collections" do
+      schema = schema_double
+      entity = make_entity("my_entity")
+      schema.entities = [entity]
+
+      result = described_class.find(schema, "my_entity")
+      expect(result).to eq(entity)
+    end
+
+    it "matches case-insensitively" do
+      schema = schema_double
+      type = make_type("My_Type")
+      schema.types = [type]
+
+      result = described_class.find(schema, "my_type")
+      expect(result).to eq(type)
+    end
+
+    it "returns nil when the element is not present" do
+      expect(described_class.find(schema_double, "missing")).to be_nil
+    end
+  end
+
+  describe Suma::LinkValidator::Step::Context do
+    it "is keyword-initialised" do
+      ctx = described_class.new(
+        file: "f", line: 1, link: "l", schema: nil, path: "p",
+      )
+      expect(ctx.file).to eq("f")
+      expect(ctx.line).to eq(1)
+      expect(ctx.link).to eq("l")
+      expect(ctx.path).to eq("p")
+    end
+  end
+
+  def make_attribute(name)
+    Expressir::Model::Declarations::Attribute.new.tap do |attr|
+      attr.id = name
+    end
+  end
+
+  def make_entity(name)
+    Expressir::Model::Declarations::Entity.new.tap do |e|
+      e.id = name
+    end
+  end
+
+  def make_type(name)
+    Expressir::Model::Declarations::Type.new.tap do |t|
+      t.id = name
+    end
+  end
+end

--- a/spec/suma/note_processor_spec.rb
+++ b/spec/suma/note_processor_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "suma/note_processor"
+require "glossarist"
+
+RSpec.describe Suma::NoteProcessor do
+  # The simplest xref_to_mention: renders {{urn,display}} strings without
+  # needing a real Urn object. Tests focus on the cleaning pipeline,
+  # not URN composition.
+  let(:xref_to_mention) do
+    ->(full_ref, display) { "{{urn:#{full_ref},#{display}}}" }
+  end
+
+  def with_definitions(content)
+    [Glossarist::V3::DetailedDefinition.new(content: content)]
+  end
+
+  describe ".call with no remarks" do
+    it "returns an empty array when remarks are nil" do
+      result = described_class.call(nil,
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result).to eq([])
+    end
+
+    it "returns an empty array when remarks are empty string" do
+      result = described_class.call("",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result).to eq([])
+    end
+  end
+
+  describe ".call with a simple sentence" do
+    it "wraps the trimmed sentence in a single DetailedDefinition" do
+      result = described_class.call("This is a note. More text.",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result.length).to eq(1)
+      expect(result.first).to be_a(Glossarist::V3::DetailedDefinition)
+      expect(result.first.content).to eq("This is a note.")
+    end
+  end
+
+  describe "image-reference filtering" do
+    it "drops a note whose content contains image::" do
+      result = described_class.call("See image::diagram.svg[].",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result).to eq([])
+    end
+  end
+
+  describe "double-angle-bracket filtering" do
+    it "drops a note whose content contains a non-express <<...>> block" do
+      # express xrefs are converted to {{urn,display}} mentions before the
+      # filter runs; the filter catches other <<...>> blocks (e.g. asciidoc
+      # cross-references that survived xref conversion).
+      result = described_class.call("Refers to <<some_other_ref>>.",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result).to eq([])
+    end
+  end
+
+  describe "see-tail stripping" do
+    it "removes trailing (see ...) clauses" do
+      result = described_class.call("Some content (see Section 4).",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result.first.content).to eq("Some content.")
+    end
+  end
+
+  describe "redundant opening note suppression" do
+    it "drops the 'An X is a type of {{...}}' opening sentence" do
+      remark = "An action is a type of {{urn:foo,foo}}. Real content here."
+      result = described_class.call(remark,
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      # After trimming to first sentence, the note is "An action is a type
+      # of {{urn:foo,foo}}." which matches REDUNDANT_NOTE_REGEX.
+      expect(result).to eq([])
+    end
+  end
+
+  describe "definition duplication" do
+    it "returns empty when the first note equals the first definition" do
+      definitions = with_definitions("Same content.")
+      result = described_class.call("Same content.",
+                                    definitions: definitions,
+                                    xref_to_mention: xref_to_mention)
+      expect(result).to eq([])
+    end
+
+    it "preserves the note when it differs from the first definition" do
+      definitions = with_definitions("Different definition.")
+      result = described_class.call("This is a note.",
+                                    definitions: definitions,
+                                    xref_to_mention: xref_to_mention)
+      expect(result.length).to eq(1)
+    end
+  end
+
+  describe "express xref → URN mention conversion" do
+    it "converts <<express:schema.entity>> to a URN mention with the entity id as display" do
+      result = described_class.call("Refers to <<express:action_schema.foo>>.",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result.first.content)
+        .to include("{{urn:action_schema.foo,foo}}")
+    end
+
+    it "converts <<express:schema.entity,Display>> to a URN mention with the explicit display" do
+      result = described_class.call("Uses <<express:action_schema.foo,Foo>>.",
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result.first.content)
+        .to include("{{urn:action_schema.foo,Foo}}")
+    end
+  end
+
+  describe "multi-paragraph list preservation" do
+    it "keeps a complete bulleted list following a colon-ended header" do
+      remark = "The attributes are:\n\n* one\n* two\n* three"
+      result = described_class.call(remark,
+                                    definitions: [],
+                                    xref_to_mention: xref_to_mention)
+      expect(result.length).to eq(1)
+      content = result.first.content
+      expect(content).to include("The attributes are:")
+      expect(content).to include("* one")
+      expect(content).to include("* two")
+      expect(content).to include("* three")
+    end
+  end
+
+  describe "REDUNDANT_NOTE_REGEX constant" do
+    it "is frozen" do
+      expect(described_class::REDUNDANT_NOTE_REGEX).to be_frozen
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three more architecture refactor candidates from the deepening review (TODOs 20–22 in `TODO.refactor/`).

- **NoteProcessor** — pure input→output module that owns the note-cleaning pipeline. Eleven private helpers + `REDUNDANT_NOTE_REGEX` move out of `TermExtractor`. URN composition injected as a callable so NoteProcessor stays independent of `Suma::Urn`. Drive-by fix: the original `split(". ")` was actually `/any-char + space/` which fragmented multi-sentence remarks — replaced with `/\. /` (literal period + space). Same in `split(".\n")`.
- **EengineConverter** — `File.read` removed from constructor. The converter now accepts XML content as a parameter; SchemaComparer reads the file and passes content. No more I/O in constructors.
- **LinkValidator Step strategies** — `validate_deep_path`'s 80-line `case` statement replaced with per-type Step classes (`Entity`, `Type`). Adding a new navigable EXPRESS construct now means adding a new Step class — no edits to existing Steps or to the dispatcher (open/closed principle). A `SchemaElementLookup` utility hides the seven-collection search so Steps don't reach into `LinkValidator`'s private methods.

All three follow the same pattern as 14–19: thin Thor adapter + deep module behind a small interface.

## Test plan

- [x] `bundle exec rake` is green locally (368 examples, 0 failures; rubocop clean)
- [x] New specs added: `note_processor_spec`, `link_validator/step_spec`
- [x] Updated spec: `eengine_converter_spec` no longer touches filesystem during construction
- [ ] CI passes on PR
