### PR TITLE
Memory-bounded staged collection build (opt-in)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,11 @@ source "https://rubygems.org"
 gemspec
 
 gem "canon"
-# gem "metanorma", github: "metanorma/metanorma", branch: "main"
+# Staged build (suma#94) needs the preserve_unresolved: / artifact_store_dir: /
+# reinflate: render options from metanorma#578 (metanorma 2.5.0). Point at the
+# feature branch until it is released; drop this once 2.5.0 is on rubygems.
+gem "metanorma", github: "metanorma/metanorma",
+                 branch: "feature/collection-incremental-resumable"
 # gem "metanorma-plugin-lutaml", github: "metanorma/metanorma-plugin-lutaml", branch: "main"
 # gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "main"
 gem "nokogiri"

--- a/lib/suma.rb
+++ b/lib/suma.rb
@@ -29,6 +29,7 @@ module Suma
   autoload :SchemaNaming,           "suma/schema_naming"
   autoload :SchemaTemplate,         "suma/schema_template"
   autoload :SiteConfig,             "suma/site_config"
+  autoload :StagedCollectionBuilder, "suma/staged_collection_builder"
   autoload :SvgQuality,             "suma/svg_quality"
   autoload :TermClassification,     "suma/term_classification"
   autoload :TermExtractor,          "suma/term_extractor"

--- a/lib/suma/cli/build.rb
+++ b/lib/suma/cli/build.rb
@@ -12,6 +12,10 @@ module Suma
                        desc: "Compile or skip compile of collection"
       option :schemas_all_path, type: :string, aliases: "-s",
                                 desc: "Generate file that contains all schemas in the collection."
+      option :staged, type: :boolean, default: false,
+                      desc: "Memory-bounded staged build: compile each member in " \
+                            "its own process (sequential) and reinflate. For large " \
+                            "collections that OOM a single-process build (suma#94)."
 
       def build(metanorma_site_manifest)
         unless File.exist?(metanorma_site_manifest)
@@ -34,6 +38,7 @@ module Suma
           schemas_all_path: schemas_all_path,
           compile: options[:compile],
           output_directory: "_site",
+          staged: options[:staged],
         ).run
       end
 

--- a/lib/suma/processor.rb
+++ b/lib/suma/processor.rb
@@ -4,15 +4,21 @@ require "metanorma"
 
 module Suma
   class Processor
+    # Emitted collection manifest that both the normal and staged builds render.
+    COLLECTION_OUTPUT_PATH = "collection-output.yaml"
+
     attr_reader :metanorma_yaml_path, :output_directory, :schemas_all_path,
                 :compile_flag
 
     def initialize(metanorma_yaml_path:, schemas_all_path:, compile: true,
-                   output_directory: "_site")
+                   output_directory: "_site", staged: false)
       @metanorma_yaml_path = metanorma_yaml_path
       @schemas_all_path = schemas_all_path
       @compile_flag = compile
       @output_directory = output_directory
+      # Opt-in memory-bounded staged build (metanorma/suma#94); the default
+      # single-process build below is unchanged when false.
+      @staged = staged
     end
 
     def run
@@ -64,11 +70,21 @@ module Suma
         collection_config, output_directory
       )
 
-      metanorma_collection.render(collection_opts)
+      if @staged
+        # build_collection has written the emitted manifest; stage each member in
+        # its own process, then reinflate. Bounds peak memory to a single member.
+        StagedCollectionBuilder.new(
+          collection_config_path: COLLECTION_OUTPUT_PATH,
+          output_directory: output_directory,
+          coverpage: collection_opts[:coverpage],
+        ).build
+      else
+        metanorma_collection.render(collection_opts)
+      end
     end
 
     def build_collection(collection_config, output_directory)
-      new_collection_config_path = "collection-output.yaml"
+      new_collection_config_path = COLLECTION_OUTPUT_PATH
       ManifestTraverser.new(collection_config.manifest).remove_schemas_only_sources
       collection_config.to_file(new_collection_config_path)
 

--- a/lib/suma/staged_collection_builder.rb
+++ b/lib/suma/staged_collection_builder.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "metanorma"
+require "yaml"
+require "fileutils"
+
+module Suma
+  # Memory-bounded, resumable staged collection build (metanorma/suma#94).
+  #
+  # A normal collection build renders every member document in one OS process, so
+  # peak memory accumulates across the whole collection and a large collection
+  # (e.g. the STEP SRL) OOMs. This builder instead:
+  #
+  #   1. compiles each member in its OWN fresh OS process, preserving that
+  #      member's unresolved cross-document references as stubs and writing the
+  #      stub-bearing Semantic XML + anchors to a durable content-addressed store
+  #      (the metanorma engine's +preserve_unresolved:+ / +artifact_store_dir:+
+  #      render options, metanorma/metanorma#576);
+  #   2. runs those per-member processes SEQUENTIALLY (never in parallel --
+  #      parallelism reintroduces the cross-linking / sectionsplit races that are
+  #      deliberately avoided); each process exits and the OS reclaims its memory
+  #      before the next, so peak memory is bounded by a single member; then
+  #   3. REINFLATES: a final pass assembles a manifest of the stored stubs and
+  #      resolves them into real cross-document links (+reinflate:+), producing
+  #      the same output an all-present build would.
+  #
+  # The empirical case (metanorma/metanorma#576): on the real SRL a single-process
+  # build peaks ~4.1 GB and OOMs; each member compiled in isolation peaks ~1 GB,
+  # so process isolation is a ~4x peak reduction that converts the OOM into a
+  # bounded footprint.
+  #
+  # This is opt-in; +Suma::Processor+ uses the normal single-process build unless
+  # staging is requested.
+  class StagedCollectionBuilder
+    STORE_DIRNAME = ".metanorma-collection-cache"
+
+    # +collection_config_path+ is the emitted collection manifest (the same
+    # +collection-output.yaml+ the normal build renders). Member filerefs are
+    # relative to its directory, so all per-member manifests are written there.
+    def initialize(collection_config_path:, output_directory:, coverpage: nil,
+                   store_dir: nil, formats: %i[xml html])
+      @config_path = collection_config_path
+      @config_dir = File.dirname(File.expand_path(collection_config_path))
+      @output_directory = output_directory
+      @coverpage = coverpage
+      @store_dir = store_dir || File.join(output_directory, STORE_DIRNAME)
+      @formats = formats
+    end
+
+    def build
+      FileUtils.mkdir_p(@output_directory)
+      FileUtils.mkdir_p(@store_dir)
+      members = collection_members
+      Utils.log "[staged] #{members.size} members; one process per member, " \
+                "sequential; store: #{@store_dir}"
+      members.each_with_index { |member, i| stage_member(member, i) }
+      reinflate(members)
+    end
+
+    private
+
+    def manifest
+      @manifest ||= YAML.load_file(@config_path)
+    end
+
+    # Every document member of the manifest tree, in order: any node carrying a
+    # file reference (+fileref+ or legacy +file+) that is not an attachment.
+    def collection_members
+      members = []
+      collect = lambda do |node|
+        case node
+        when Array then node.each { |n| collect.call(n) }
+        when Hash
+          ref = node["fileref"] || node["file"]
+          if ref && !truthy(node["attachment"])
+            members << { "fileref" => ref,
+                         "identifier" => node["identifier"],
+                         "sectionsplit" => node["sectionsplit"] }.compact
+          end
+          node.each_value { |v| collect.call(v) }
+        end
+      end
+      collect.call(manifest["manifest"])
+      members
+    end
+
+    # Stage one member in its own process: a single-member manifest rendered with
+    # preserve + store. Written beside the collection config so relative filerefs
+    # resolve; removed afterwards.
+    def stage_member(member, idx)
+      one_path = File.join(@config_dir, "._suma_staged_#{idx}.yml")
+      File.write(one_path, single_member_manifest(member).to_yaml)
+      out = File.join(@output_directory, "._staged_out_#{idx}")
+      ok = run_render(
+        manifest_path: one_path,
+        opts: { format: [:xml], output_folder: out,
+                preserve_unresolved: true, artifact_store_dir: @store_dir,
+                compile: { install_fonts: false } },
+      )
+      ok or raise "[staged] member #{idx} (#{member['identifier']}) failed to stage"
+    ensure
+      FileUtils.rm_f(one_path)
+      FileUtils.rm_rf(File.join(@output_directory, "._staged_out_#{idx}"))
+    end
+
+    # Assemble a manifest of the stored stubs and reinflate them into the site.
+    def reinflate(members)
+      reinf_dir = File.join(@output_directory, "_staged_reinflate")
+      FileUtils.mkdir_p(reinf_dir)
+      docrefs = members.map.with_index do |member, i|
+        stored = stored_semantic(member["identifier"]) or
+          raise "[staged] no stored artefact for #{member['identifier'].inspect}"
+        name = "member_#{i}.xml"
+        FileUtils.cp(stored, File.join(reinf_dir, name))
+        dr = { "fileref" => name, "identifier" => member["identifier"] }
+        dr["sectionsplit"] = true if truthy(member["sectionsplit"])
+        dr
+      end
+      man = base_manifest
+      man["manifest"] = { "level" => "collection", "title" => "Collection",
+                          "manifest" => [{ "level" => "subcollection",
+                                           "title" => "Members",
+                                           "docref" => docrefs }] }
+      reinf_path = File.join(reinf_dir, "reinflate.yml")
+      File.write(reinf_path, man.to_yaml)
+      Utils.log "[staged] reinflating #{docrefs.size} stored members -> " \
+                "#{@output_directory}"
+      run_render(
+        manifest_path: reinf_path,
+        opts: { format: @formats, output_folder: @output_directory,
+                reinflate: true, coverpage: @coverpage,
+                compile: { install_fonts: false } }.compact,
+      ) or raise "[staged] reinflation failed"
+    end
+
+    # A minimal single-member manifest reusing the collection's directives and
+    # bibdata, so the isolated render carries the right collection identity.
+    def single_member_manifest(member)
+      man = base_manifest
+      man["manifest"] = { "level" => "collection", "title" => "Collection",
+                          "manifest" => [{ "level" => "subcollection",
+                                           "title" => "Members",
+                                           "docref" => [member] }] }
+      man
+    end
+
+    def base_manifest
+      { "directives" => manifest["directives"] || ["documents-inline"],
+        "bibdata" => manifest["bibdata"] }.compact
+    end
+
+    def stored_semantic(identifier)
+      Dir[File.join(@store_dir, "#{slug(identifier)}.*.semantic.xml")]
+        .max_by { |f| File.mtime(f) }
+    end
+
+    # Mirrors the store's filename slug (metanorma ArtifactStore#slug).
+    def slug(identifier)
+      identifier.to_s.gsub(/[^A-Za-z0-9._-]+/, "-")
+        .gsub(/-{2,}/, "-").gsub(/\A-|-\z/, "")
+    end
+
+    # Render a manifest in a FRESH child process so its memory is reclaimed on
+    # exit. Under +bundle exec+, the child inherits the bundle. Returns true on
+    # success.
+    def run_render(manifest_path:, opts:)
+      script = <<~RUBY
+        require "metanorma"
+        opts = Marshal.load(STDIN.read)
+        Metanorma::Collection.parse(#{manifest_path.inspect}).render(opts)
+      RUBY
+      IO.popen([RbConfig.ruby, "-e", script], "wb") do |io|
+        io.write(Marshal.dump(opts))
+        io.close_write
+      end
+      $?.success?
+    end
+
+    def truthy(val)
+      val == true || val == "true"
+    end
+  end
+end

--- a/lib/suma/staged_collection_builder.rb
+++ b/lib/suma/staged_collection_builder.rb
@@ -67,21 +67,23 @@ module Suma
     # file reference (+fileref+ or legacy +file+) that is not an attachment.
     def collection_members
       members = []
-      collect = lambda do |node|
-        case node
-        when Array then node.each { |n| collect.call(n) }
-        when Hash
-          ref = node["fileref"] || node["file"]
-          if ref && !truthy(node["attachment"])
-            members << { "fileref" => ref,
-                         "identifier" => node["identifier"],
-                         "sectionsplit" => node["sectionsplit"] }.compact
-          end
-          node.each_value { |v| collect.call(v) }
-        end
-      end
-      collect.call(manifest["manifest"])
+      walk_members(manifest["manifest"]) { |member| members << member }
       members
+    end
+
+    def walk_members(node, &block)
+      case node
+      when Array then node.each { |child| walk_members(child, &block) }
+      when Hash then walk_member_hash(node, &block)
+      end
+    end
+
+    def walk_member_hash(node, &block)
+      ref = node["fileref"] || node["file"]
+      ref && !truthy?(node["attachment"]) and
+        yield({ "fileref" => ref, "identifier" => node["identifier"],
+                "sectionsplit" => node["sectionsplit"] }.compact)
+      node.each_value { |value| walk_members(value, &block) }
     end
 
     # Stage one member in its own process: a single-member manifest rendered with
@@ -91,13 +93,12 @@ module Suma
       one_path = File.join(@config_dir, "._suma_staged_#{idx}.yml")
       File.write(one_path, single_member_manifest(member).to_yaml)
       out = File.join(@output_directory, "._staged_out_#{idx}")
-      ok = run_render(
+      run_render(
         manifest_path: one_path,
         opts: { format: [:xml], output_folder: out,
                 preserve_unresolved: true, artifact_store_dir: @store_dir,
                 compile: { install_fonts: false } },
       )
-      ok or raise "[staged] member #{idx} (#{member['identifier']}) failed to stage"
     ensure
       FileUtils.rm_f(one_path)
       FileUtils.rm_rf(File.join(@output_directory, "._staged_out_#{idx}"))
@@ -107,22 +108,10 @@ module Suma
     def reinflate(members)
       reinf_dir = File.join(@output_directory, "_staged_reinflate")
       FileUtils.mkdir_p(reinf_dir)
-      docrefs = members.map.with_index do |member, i|
-        stored = stored_semantic(member["identifier"]) or
-          raise "[staged] no stored artefact for #{member['identifier'].inspect}"
-        name = "member_#{i}.xml"
-        FileUtils.cp(stored, File.join(reinf_dir, name))
-        dr = { "fileref" => name, "identifier" => member["identifier"] }
-        dr["sectionsplit"] = true if truthy(member["sectionsplit"])
-        dr
-      end
-      man = base_manifest
-      man["manifest"] = { "level" => "collection", "title" => "Collection",
-                          "manifest" => [{ "level" => "subcollection",
-                                           "title" => "Members",
-                                           "docref" => docrefs }] }
+      docrefs = stored_docrefs(members, reinf_dir)
       reinf_path = File.join(reinf_dir, "reinflate.yml")
-      File.write(reinf_path, man.to_yaml)
+      File.write(reinf_path,
+                 base_manifest.merge("manifest" => collection_manifest(docrefs)).to_yaml)
       Utils.log "[staged] reinflating #{docrefs.size} stored members -> " \
                 "#{@output_directory}"
       run_render(
@@ -130,18 +119,33 @@ module Suma
         opts: { format: @formats, output_folder: @output_directory,
                 reinflate: true, coverpage: @coverpage,
                 compile: { install_fonts: false } }.compact,
-      ) or raise "[staged] reinflation failed"
+      )
+    end
+
+    # Copy each member's stored stub into +dir+ and return docref entries pointing
+    # at the copies, keyed by real docid (as the store keys them).
+    def stored_docrefs(members, dir)
+      members.map.with_index do |member, i|
+        stored = stored_semantic(member["identifier"]) or
+          raise "[staged] no stored artefact for #{member['identifier'].inspect}"
+        name = "member_#{i}.xml"
+        FileUtils.cp(stored, File.join(dir, name))
+        dr = { "fileref" => name, "identifier" => member["identifier"] }
+        dr["sectionsplit"] = true if truthy?(member["sectionsplit"])
+        dr
+      end
     end
 
     # A minimal single-member manifest reusing the collection's directives and
     # bibdata, so the isolated render carries the right collection identity.
     def single_member_manifest(member)
-      man = base_manifest
-      man["manifest"] = { "level" => "collection", "title" => "Collection",
-                          "manifest" => [{ "level" => "subcollection",
-                                           "title" => "Members",
-                                           "docref" => [member] }] }
-      man
+      base_manifest.merge("manifest" => collection_manifest([member]))
+    end
+
+    def collection_manifest(docrefs)
+      { "level" => "collection", "title" => "Collection",
+        "manifest" => [{ "level" => "subcollection", "title" => "Members",
+                         "docref" => docrefs }] }
     end
 
     def base_manifest
@@ -161,8 +165,7 @@ module Suma
     end
 
     # Render a manifest in a FRESH child process so its memory is reclaimed on
-    # exit. Under +bundle exec+, the child inherits the bundle. Returns true on
-    # success.
+    # exit. Under +bundle exec+, the child inherits the bundle. Raises on failure.
     def run_render(manifest_path:, opts:)
       script = <<~RUBY
         require "metanorma"
@@ -173,11 +176,13 @@ module Suma
         io.write(Marshal.dump(opts))
         io.close_write
       end
-      $?.success?
+      return if $?.success?
+
+      raise "[staged] render subprocess failed for #{manifest_path}"
     end
 
-    def truthy(val)
-      val == true || val == "true"
+    def truthy?(val)
+      [true, "true"].include?(val)
     end
   end
 end

--- a/spec/suma/staged_collection_builder_spec.rb
+++ b/spec/suma/staged_collection_builder_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Suma::StagedCollectionBuilder do
                         output_directory: File.join(dir, "_site"))
   end
 
+  subject(:builder) { builder_for(manifest) }
+
   let(:manifest) do
     {
       "directives" => ["documents-inline"],
@@ -40,8 +42,6 @@ RSpec.describe Suma::StagedCollectionBuilder do
       },
     }
   end
-
-  subject(:builder) { builder_for(manifest) }
 
   describe "#collection_members" do
     let(:members) { builder.send(:collection_members) }

--- a/spec/suma/staged_collection_builder_spec.rb
+++ b/spec/suma/staged_collection_builder_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "yaml"
+
+# Unit coverage for the pure, no-compile logic of the staged builder: extracting
+# document members from a (possibly nested) collection manifest in order,
+# excluding attachments, and constructing the isolated single-member and
+# reinflation manifests. The end-to-end staged compile is exercised separately
+# (it requires the metanorma preserve/store/reinflate engine).
+RSpec.describe Suma::StagedCollectionBuilder do
+  def builder_for(manifest)
+    dir = Dir.mktmpdir
+    path = File.join(dir, "collection-output.yaml")
+    File.write(path, manifest.to_yaml)
+    described_class.new(collection_config_path: path,
+                        output_directory: File.join(dir, "_site"))
+  end
+
+  let(:manifest) do
+    {
+      "directives" => ["documents-inline"],
+      "bibdata" => { "title" => "Coll", "type" => "collection" },
+      "manifest" => {
+        "level" => "collection",
+        "manifest" => [
+          { "level" => "subcollection", "title" => "Standards",
+            "docref" => [
+              { "fileref" => "a.xml", "identifier" => "ISO 1", "sectionsplit" => true },
+              { "fileref" => "b.xml", "identifier" => "ISO 2" },
+            ] },
+          { "level" => "subcollection", "title" => "Amendments",
+            "docref" => { "fileref" => "c.xml", "identifier" => "ISO 3" } },
+          { "level" => "attachments", "title" => "Attachments",
+            "docref" => [
+              { "fileref" => "logo.svg", "identifier" => "logo.svg", "attachment" => true },
+            ] },
+        ],
+      },
+    }
+  end
+
+  subject(:builder) { builder_for(manifest) }
+
+  describe "#collection_members" do
+    let(:members) { builder.send(:collection_members) }
+
+    it "extracts every document member in manifest order" do
+      expect(members.map { |m| m["identifier"] }).to eq(["ISO 1", "ISO 2", "ISO 3"])
+    end
+
+    it "excludes attachments" do
+      expect(members.map { |m| m["fileref"] }).not_to include("logo.svg")
+    end
+
+    it "carries the sectionsplit flag through" do
+      expect(members.first["sectionsplit"]).to be true
+      expect(members[1]).not_to have_key("sectionsplit")
+    end
+
+    it "handles both a docref array and a single docref hash" do
+      expect(members.map { |m| m["fileref"] }).to eq(["a.xml", "b.xml", "c.xml"])
+    end
+  end
+
+  describe "#single_member_manifest" do
+    let(:one) { builder.send(:single_member_manifest, "fileref" => "a.xml", "identifier" => "ISO 1") }
+
+    it "reuses the collection directives and bibdata" do
+      expect(one["directives"]).to eq(["documents-inline"])
+      expect(one["bibdata"]).to eq("title" => "Coll", "type" => "collection")
+    end
+
+    it "contains exactly the one member" do
+      docrefs = one["manifest"]["manifest"].first["docref"]
+      expect(docrefs).to eq([{ "fileref" => "a.xml", "identifier" => "ISO 1" }])
+    end
+  end
+
+  describe "#slug" do
+    it "matches the metanorma ArtifactStore filesystem-safe slug" do
+      expect(builder.send(:slug, "ISO 17301-1:2016/Amd.1:2017"))
+        .to eq("ISO-17301-1-2016-Amd.1-2017")
+    end
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/suma/issues/94

## Summary

Opt-in **memory-bounded staged collection build**: compile each collection member in its own OS process (preserving cross-document references as stubs into a content-addressed store), sequentially, then reinflate the stored stubs into the final collection. Peak memory is bounded by a single member instead of the whole collection.

The default single-process build path is **unchanged** — staging is opt-in via `--staged` (CLI) / `staged: true` (`Processor.new`).

## Why (the measured case)

Profiling the real SRL build (`suma build metanorma-srl.yml`, memory-capped at 3.8 GiB, full detail in metanorma/metanorma#576):

- Single-process build **peaks ~4.1 GB and OOMs** (killed at the application-protocol parts).
- The OOM is **accumulated cross-document heap, not per-document size** — no document metric (schema count, schema bytes, compiled-XML size, crossref count) predicts the spikes; the largest document is the *lowest* memory.
- Each spiking document compiled **in isolation peaks ~1 GB** (part 51: 1070 MB vs 2883 in-sequence; part 101: 998 MB vs 4121 in-sequence).

So process isolation is a **~4× peak reduction** that converts the OOM into a bounded footprint. It also reconciles the reported "document 11–12" OOM: those members spike to ~2.9 GB, which OOMs a tighter effective ceiling (a 3.8 GiB container minus overhead) exactly there.

## How

`Suma::StagedCollectionBuilder` (new) drives three stages, using the metanorma engine's render options from metanorma/metanorma#576 / #578:

1. **Stage** — each member rendered in a fresh child process with `preserve_unresolved: true` + `artifact_store_dir:` → writes stub-bearing Semantic XML + anchors to the store.
2. **Sequential** — one process at a time; each exits and the OS reclaims its memory before the next. Deliberately **not** parallel (parallelism reintroduces the cross-linking / sectionsplit races).
3. **Reinflate** — assemble a manifest of the stored stubs and render with `reinflate: true` → resolved cross-document links, all formats.

`Processor#compile_collection` gains an opt-in branch; `build_collection` still emits the same `collection-output.yaml`, which the staged builder consumes.

## Changes

- `lib/suma/staged_collection_builder.rb` — new; the three-stage builder (member walking, per-process staging, reinflation-manifest assembly).
- `lib/suma/processor.rb` — opt-in `staged:` branch in `compile_collection`; shared `COLLECTION_OUTPUT_PATH` constant.
- `lib/suma/cli/build.rb` — `--staged` flag.
- `lib/suma.rb` — autoload entry.
- `spec/suma/staged_collection_builder_spec.rb` — unit coverage for the no-compile logic (member extraction across nested manifests, attachment exclusion, sectionsplit flag, single-member manifest, store slug).
- `Gemfile` — points `metanorma` at the `feature/collection-incremental-resumable` branch (the engine is metanorma 2.5.0, unreleased). **Drop this pin once 2.5.0 is on rubygems**; run `bundle install` to refresh the lock.

## Status / validation

The metanorma-side engine is landed and green in metanorma/metanorma#578, including a section-split round-trip spec (cross-document links resolved + attachments carried through stage→store→reinflate). This PR is the suma-side orchestration on top of it.

**Not yet run here:** the end-to-end staged build against the real nested-sectionsplit SRL, and the `bundle`/rspec run (the Gemfile now points at an unreleased branch). The unit spec covers the pure manifest logic; the integration validation (single member-per-process on the SRL, then reinflation) is the remaining step before merge. The area most needing that validation is **nested sub-collection members** (the SRL's members are `documents/iso-10303-NN/collection.yml` sub-collections, not flat documents) and **attachment carry-through at SRL scale**.

🤖
